### PR TITLE
feat: Migrate cabal from simple to custom setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,22 @@ by generating FFI shims directly from the official `duckdb.h` header.
   so you can pick between granular or aggregate re-exports.
 - Ships with an exhaustive test suite that exercises every binding to catch
   signature drift when DuckDB evolves.
-- Validated against DuckDB 1.5.0+ releases. Ensure the native
-  `libduckdb` shared library is installed on your system (for example via
-  https://duckdb.org/install/?platform=linux&environment=c&architecture=x86_64)
-  before linking a Haskell application against the bindings.
+- Validated against DuckDB 1.5.0+ releases.
+
+### Installation
+
+`cabal build` automatically downloads the platform-specific `libduckdb` shared
+library from the [DuckDB GitHub releases](https://github.com/duckdb/duckdb/releases)
+and caches it under `~/.cache/duckdb/<version>/<platform>/` (XDG cache).
+No manual installation is required on Linux (x86_64) or macOS.
+
+The following environment variables customise this behaviour:
+
+* `DUCKDB_VERSION`: (default `1.5.0`) DuckDB release to download
+* `DUCKDB_HOME`: (`~/.cache/duckdb`) Override the cache root directory
+* `DUCKDB_SKIP_DOWNLOAD`: (default *(unset)*) Set to any value to skip the download and link against a system-installed `libduckdb` instead.
+
+NB: Nix builds are detected via a heuristic `NIX_BUILD_TOP` and the download is skipped; `libduckdb` must be provided by the Nix environment in that case (the current flake does not do this).
 
 `duckdb-ffi` is ideal when you need precise control over DuckDB’s C API, want to
 interoperate with other native components, or plan to build higher-level

--- a/duckdb-ffi/Setup.hs
+++ b/duckdb-ffi/Setup.hs
@@ -1,3 +1,155 @@
-import Distribution.Simple
+{-# LANGUAGE CPP #-}
 
-main = defaultMain
+import Data.List (isPrefixOf)
+import Distribution.Simple
+import Distribution.Simple.Program
+import Distribution.Simple.Setup
+import Distribution.Simple.LocalBuildInfo
+import Distribution.Types.LocalBuildInfo
+import Distribution.Types.GenericPackageDescription
+import Distribution.Types.HookedBuildInfo
+import Distribution.PackageDescription
+import Distribution.System
+import System.Directory
+import System.FilePath
+import System.IO.Temp
+import Network.HTTP.Simple
+import qualified Data.ByteString.Lazy as LBS
+import System.Environment (lookupEnv)
+import Data.Maybe (fromMaybe)
+import GHC.IO.Exception
+import Control.Exception
+import Codec.Archive.Zip
+
+#if MIN_VERSION_Cabal(3,14,0)
+import Distribution.Utils.Path (makeSymbolicPath)
+#else
+
+makeSymbolicPath :: a -> a
+makeSymbolicPath = id
+#endif
+
+main :: IO ()
+main = defaultMainWithHooks $ simpleUserHooks
+  { preConf = \_ _ -> do
+      pure emptyHookedBuildInfo
+  , confHook = \(gpd, hbi) flags -> do
+      mDuckDBDir <- ensureDuckDB
+      case mDuckDBDir of
+        Nothing -> do
+          putStrLn "libduckdb not found in cache, skipping extra configuration."
+          confHook simpleUserHooks (gpd, hbi) flags
+        Just duckdbDir -> do
+          let updatedFlags = flags
+                { configExtraLibDirs     = makeSymbolicPath duckdbDir : configExtraLibDirs flags
+                , configExtraIncludeDirs = makeSymbolicPath duckdbDir : configExtraIncludeDirs flags
+                }
+          lbi <- confHook simpleUserHooks (gpd, hbi) updatedFlags
+          case buildOS of
+            OSX   -> return $ lbi { withPrograms = addRPath duckdbDir (withPrograms lbi) }
+            Linux -> return $ lbi { withPrograms = addRPath duckdbDir (withPrograms lbi) }
+            _     -> return lbi
+  }
+
+-- Default to the version of libduckdb recommended in the README
+getDuckDBVersion :: IO String
+getDuckDBVersion = fromMaybe "1.5.0" <$> lookupEnv "DUCKDB_VERSION"
+
+getLocalUserDuckDBDir :: IO FilePath
+getLocalUserDuckDBDir = do
+  mHome <- lookupEnv "DUCKDB_HOME"
+  version <- getDuckDBVersion
+  base <- case mHome of
+    Just h  -> pure h
+    Nothing -> getXdgDirectory XdgCache "duckdb"
+  pure $ base </> version </> platformTag
+
+platformTag :: String
+platformTag =
+  case (buildOS, buildArch) of
+    (Linux, X86_64)  -> "linux-amd64"
+    (OSX,   _)       -> "osx-universal"
+    _ -> error $ "Unsupported platform: " <> show (buildOS, buildArch)
+
+ensureDuckDB :: IO (Maybe FilePath)
+ensureDuckDB = do
+  isSandbox <- isNixSandbox
+  if isSandbox
+    then return Nothing
+    else downloadDuckDB
+
+isNixSandbox :: IO Bool
+isNixSandbox = do
+  nix <- lookupEnv "NIX_BUILD_TOP"
+  case nix of
+    Just path ->
+      if any (`isPrefixOf` path) ["/build", "/private/tmp/nix-build"]
+        then do
+          putStrLn "Nix sandbox detected; skipping libduckdb download."
+          return True
+        else return False
+    Nothing -> return False
+
+downloadDuckDB :: IO (Maybe FilePath)
+downloadDuckDB = do
+  skip <- lookupEnv "DUCKDB_SKIP_DOWNLOAD"
+  case skip of
+    Just _ -> do
+      putStrLn "DUCKDB_SKIP_DOWNLOAD set; assuming libduckdb exists globally."
+      return Nothing
+    Nothing -> do
+      dest <- getLocalUserDuckDBDir
+      let marker = dest </> ".ok"
+      exists <- doesFileExist marker
+      present <- doesDirectoryExist dest
+      if present && exists
+        then pure $ Just dest
+        else do
+          putStrLn $ "libduckdb not found in local cache, installing to " <> dest
+          downloadAndExtractDuckDBTo dest
+          writeFile marker ""
+          pure $ Just dest
+
+downloadAndExtractDuckDBTo :: FilePath -> IO ()
+downloadAndExtractDuckDBTo dest = do
+  createDirectoryIfMissing True dest
+  (url, fileName) <- computeURL
+  putStrLn $ "Downloading libduckdb from: " ++ url
+  withSystemTempDirectory "duckdb-download" $ \tmpDir -> do
+    let downloadPath = tmpDir </> fileName
+    request  <- parseRequest url
+    response <- httpLBS request
+    LBS.writeFile downloadPath (getResponseBody response)
+    putStrLn "Download complete. Extracting..."
+    archive <- toArchive <$> LBS.readFile downloadPath
+    let extractDir = tmpDir </> "extracted"
+    createDirectoryIfMissing True extractDir
+    extractFilesFromArchive [OptDestination extractDir] archive
+    (renameDirectory extractDir dest) `catch` (\(_ :: IOException) -> copyTree extractDir dest)
+    putStrLn "libduckdb extracted successfully (global cache)."
+
+copyTree :: FilePath -> FilePath -> IO ()
+copyTree src dest = do
+  createDirectoryIfMissing True dest
+  entries <- listDirectory src
+  mapM_ (\e -> do
+          let s = src  </> e
+              d = dest </> e
+          isDir <- doesDirectoryExist s
+          if isDir then copyTree s d else copyFile s d
+        ) entries
+
+computeURL :: IO (String, String)
+computeURL = do
+  v <- getDuckDBVersion
+  let base = "https://github.com/duckdb/duckdb/releases/download/v" ++ v ++ "/"
+  pure $ case buildOS of
+    Linux -> ( base ++ "libduckdb-linux-amd64.zip", "libduckdb-linux-amd64.zip" )
+    OSX   -> ( base ++ "libduckdb-osx-universal.zip", "libduckdb-osx-universal.zip" )
+    _     -> error "Unsupported OS for libduckdb download"
+
+addRPath :: FilePath -> ProgramDb -> ProgramDb
+addRPath libDir progDb =
+  userSpecifyArgs (programName ldProgram)
+  ["-Wl,-rpath," ++ libDir]
+  progDb

--- a/duckdb-ffi/duckdb-ffi.cabal
+++ b/duckdb-ffi/duckdb-ffi.cabal
@@ -4,7 +4,7 @@ version: 1.5.0.0
 author: Matthias Pall Gissurarson
 maintainer: mpg@mpg.is
 category: Database
-build-type: Simple
+build-type: Custom
 tested-with:
   ghc ==9.6.*
   ghc ==9.8.*
@@ -31,6 +31,17 @@ source-repository head
   type: git
   location: https://github.com/Tritlo/duckdb-haskell.git
   subdir: duckdb-ffi
+
+custom-setup
+  setup-depends:
+    base,
+    Cabal >= 3.4,
+    bytestring,
+    directory,
+    filepath,
+    http-conduit,
+    temporary,
+    zip-archive,
 
 library
   default-language:
@@ -113,10 +124,6 @@ library
     text >=2.0 && <2.2,
     time >=1.12 && <1.16,
     transformers >=0.6 && <0.7,
-
-  if os(linux)
-    ghc-options: "-optl-Wl,-rpath,'$ORIGIN/../cbits/duckdb'"
-    ld-options: "-Wl,-rpath,'$ORIGIN/../cbits/duckdb'"
 
 test-suite duckdb-ffi-tests
   type: exitcode-stdio-1.0

--- a/duckdb-ffi/test/BindValuesTest.hs
+++ b/duckdb-ffi/test/BindValuesTest.hs
@@ -6,6 +6,7 @@ import Control.Monad (when)
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.List (intercalate)
 import Data.Time.Calendar (diffDays, fromGregorian)
+import Data.Time.LocalTime (getCurrentTimeZone, timeZoneMinutes)
 import Data.Word (Word16, Word32, Word64, Word8)
 import Database.DuckDB.FFI
 import Database.DuckDB.FFI.Deprecated
@@ -167,8 +168,10 @@ bindValuesRoundtrip =
                         fetchedTs @?= duckDBTimestampMicros timestampValue
 
                         DuckDBTimestamp fetchedTsTz <- c_duckdb_value_timestamp resPtr 17 0
-                        let tzDifference = fetchedTsTz - duckDBTimestampMicros timestampValue
-                        tzDifference @?= 7200000000
+                        tz <- getCurrentTimeZone
+                        let tzOffsetMicros = fromIntegral (timeZoneMinutes tz) * 60 * 1000000
+                            tzDifference = fetchedTsTz - duckDBTimestampMicros timestampValue
+                        tzDifference @?= tzOffsetMicros
 
                         alloca \intervalPtr -> do
                             c_duckdb_value_interval resPtr 18 0 intervalPtr

--- a/duckdb-simple/src/Database/DuckDB/Simple.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple.hs
@@ -101,7 +101,7 @@ import Database.DuckDB.Simple.FromRow (
     parseRow,
     rowErrorsToSqlError,
  )
-import Database.DuckDB.Simple.Function (Function, createFunction, createFunctionWithState, deleteFunction)
+import Database.DuckDB.Simple.Function (Function (..), createFunction, createFunctionWithState, deleteFunction)
 import Database.DuckDB.Simple.Internal (
     Connection (..),
     ConnectionState (..),


### PR DESCRIPTION
This mirrors the hasktorch installation script and uses the same logic to detect whether we are in nix.

This will still require a proper nix setup but will automatically download duckdb for cabal installation.

Also fixes the issues that were causing build failures so we can verify successful cabal setup from CI.

Addresses: #4 and #8