### PR TITLE
Bump bounds for quickcheck

### DIFF
--- a/duckdb-simple/duckdb-simple.cabal
+++ b/duckdb-simple/duckdb-simple.cabal
@@ -76,7 +76,7 @@ test-suite duckdb-simple-test
   other-modules: Properties
   default-language: Haskell2010
   build-depends:
-    QuickCheck >=2.14 && <2.15,
+    QuickCheck >=2.14 && <2.16,
     array >=0.5 && <0.6,
     base >=4.14 && <5,
     bytestring,
@@ -87,7 +87,7 @@ test-suite duckdb-simple-test
     tasty >=1.4 && <1.6,
     tasty-expected-failure >=0.12 && <0.13,
     tasty-hunit >=0.10 && <0.12,
-    tasty-quickcheck >=0.10 && <0.11,
+    tasty-quickcheck >=0.10 && <0.12,
     text,
     time,
     uuid >=1.3 && <1.4,


### PR DESCRIPTION
builds on NixOS x86-64 (wsl), nixpkgs 25.11