### PR TITLE
Move RowParser into Internal.hs

### DIFF
--- a/duckdb-simple/src/Database/DuckDB/Simple.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple.hs
@@ -101,7 +101,7 @@ import Database.DuckDB.Simple.FromRow (
     parseRow,
     rowErrorsToSqlError,
  )
-import Database.DuckDB.Simple.Function (Function, createFunction, createFunctionWithState, deleteFunction)
+import Database.DuckDB.Simple.Function (Function (..), createFunction, createFunctionWithState, deleteFunction)
 import Database.DuckDB.Simple.Internal (
     Connection (..),
     ConnectionState (..),

--- a/duckdb-simple/src/Database/DuckDB/Simple/FromField.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/FromField.hs
@@ -51,13 +51,21 @@ import Data.Time.Clock (UTCTime (..))
 import Data.Time.LocalTime (
     LocalTime (..),
     TimeOfDay (..),
-    TimeZone (..),
     localTimeToUTC,
     utc,
     utcToLocalTime,
  )
 import qualified Data.UUID as UUID
 import Data.Word (Word16, Word32, Word64, Word8)
+import Database.DuckDB.Simple.Internal (
+  BigNum (..),
+  BitString (..),
+  DecimalValue (..),
+  Field (..),
+  FieldValue (..),
+  IntervalValue (..),
+  TimeWithZone (..),
+ )
 import Database.DuckDB.Simple.LogicalRep (
     LogicalTypeRep (..),
     StructField (..),
@@ -69,63 +77,6 @@ import Database.DuckDB.Simple.Ok
 import Database.DuckDB.Simple.Types (Null (..))
 import GHC.Num.Integer (integerFromWordList)
 import Numeric.Natural (Natural)
-
--- | Internal representation of a column value.
-data FieldValue
-    = FieldNull
-    | FieldInt8 Int8
-    | FieldInt16 Int16
-    | FieldInt32 Int32
-    | FieldInt64 Int64
-    | FieldWord8 Word8
-    | FieldWord16 Word16
-    | FieldWord32 Word32
-    | FieldWord64 Word64
-    | FieldUUID UUID.UUID
-    | FieldFloat Float
-    | FieldDouble Double
-    | FieldText Text
-    | FieldBool Bool
-    | FieldBlob BS.ByteString
-    | FieldDate Day
-    | FieldTime TimeOfDay
-    | FieldTimestamp LocalTime
-    | FieldInterval IntervalValue
-    | FieldHugeInt Integer
-    | FieldUHugeInt Integer
-    | FieldDecimal DecimalValue
-    | FieldTimestampTZ UTCTime
-    | FieldTimeTZ TimeWithZone
-    | FieldBit BitString
-    | FieldBigNum BigNum
-    | FieldEnum Word32
-    | FieldArray (Array Int FieldValue)
-    | FieldList [FieldValue]
-    | FieldMap [(FieldValue, FieldValue)]
-    | FieldStruct (StructValue FieldValue)
-    | FieldUnion (UnionValue FieldValue)
-    deriving (Eq, Show)
-
--- | Exact-width decimal payload plus its declared width and scale.
-data DecimalValue = DecimalValue
-    { decimalWidth :: !Word8
-    , decimalScale :: !Word8
-    , decimalInteger :: !Integer
-    }
-    deriving (Eq, Show)
-
--- | DuckDB interval payload split into months, days, and microseconds.
-data IntervalValue = IntervalValue
-    { intervalMonths :: !Int32
-    , intervalDays :: !Int32
-    , intervalMicros :: !Int64
-    }
-    deriving (Eq, Show)
-
--- | Arbitrary-precision integer wrapper used for DuckDB's BIGNUM type.
-newtype BigNum = BigNum Integer
-    deriving stock (Eq, Show)
-    deriving (Num) via Integer
 
 {- | Decode DuckDB’s BIGNUM blob (3-byte header + big-endian payload where negative magnitudes are
 bitwise complemented) back into a Haskell @Integer@. We undo the complement when needed, then chunk
@@ -182,20 +133,6 @@ toBigNumBytes value =
         payloadBytes = if isNeg then map complement payloadBE else payloadBE
      in headerBytes <> payloadBytes
 
--- | DuckDB BIT value represented as raw bytes plus left-padding bit count.
-data BitString = BitString
-    { padding :: !Word8
-    , bits :: !BS.ByteString
-    }
-    deriving stock (Eq)
-
-instance Show BitString where
-    show (BitString padding bits) =
-        drop (fromIntegral padding) $ concatMap word8ToString $ BS.unpack bits
-      where
-        word8ToString :: Word8 -> String
-        word8ToString w = map (\n -> if testBit w n then '1' else '0') [7, 6 .. 0]
-
 -- | Construct a @BitString@ from a list of @Bool@s, where the first element
 bsFromBool :: [Bool] -> BitString
 bsFromBool bits =
@@ -211,13 +148,6 @@ bsFromBool bits =
 
     bitsToWord8 :: [Bool] -> Word8
     bitsToWord8 bs = foldl (\acc (b, i) -> if b then setBit acc i else acc) 0 (zip bs [7, 6 .. 0])
-
--- | Time-of-day paired with its associated timezone offset.
-data TimeWithZone = TimeWithZone
-    { timeWithZoneTime :: !TimeOfDay
-    , timeWithZoneZone :: !TimeZone
-    }
-    deriving (Eq, Show)
 
 -- | Pattern synonym to make it easier to match on any integral type.
 pattern FieldInt :: Int -> FieldValue
@@ -244,14 +174,6 @@ fieldValueToWord (FieldWord16 i) = Just (fromIntegral i)
 fieldValueToWord (FieldWord32 i) = Just (fromIntegral i)
 fieldValueToWord (FieldWord64 i) = Just (fromIntegral i)
 fieldValueToWord _ = Nothing
-
--- | Metadata for a single column in a row.
-data Field = Field
-    { fieldName :: Text
-    , fieldIndex :: Int
-    , fieldValue :: FieldValue
-    }
-    deriving (Eq, Show)
 
 {- | Exception thrown if conversion from a SQL value to a Haskell
 value fails.

--- a/duckdb-simple/src/Database/DuckDB/Simple/FromRow.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/FromRow.hs
@@ -29,39 +29,26 @@ module Database.DuckDB.Simple.FromRow (
     rowErrorsToSqlError,
 ) where
 
-import Control.Applicative (Alternative (..))
 import Control.Exception (Exception, SomeException (SomeException), fromException, toException)
-import Control.Monad (MonadPlus, replicateM)
+import Control.Monad (replicateM)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
-import Control.Monad.Trans.State.Strict (StateT, get, put, runStateT)
+import Control.Monad.Trans.Reader (ask, runReaderT)
+import Control.Monad.Trans.State.Strict (get, put, runStateT)
 import Data.Maybe (listToMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import GHC.Generics
 
 import Database.DuckDB.Simple.FromField
-import Database.DuckDB.Simple.Internal (SQLError (..))
+import Database.DuckDB.Simple.Internal (RowParser (..), RowParseRO (..), SQLError (..))
 import Database.DuckDB.Simple.Ok (Ok (..))
 import Database.DuckDB.Simple.Types (Only (..), Query, (:.) (..))
-
--- | Row parsing environment (read-only data available to the parser).
-newtype RowParseRO = RowParseRO
-    { rowParseColumnCount :: Int
-    }
 
 -- | Column-out-of-bounds sentinel used internally to map parser failures.
 newtype ColumnOutOfBounds = ColumnOutOfBounds {columnOutOfBoundsIndex :: Int}
     deriving stock (Eq, Show)
 
 instance Exception ColumnOutOfBounds
-
--- | Parser used by @FromRow@ implementations.
-newtype RowParser a = RowParser
-    { runRowParser :: ReaderT RowParseRO (StateT (Int, [Field]) Ok) a
-    }
-    deriving stock (Functor)
-    deriving newtype (Applicative, Alternative, Monad, MonadPlus)
 
 -- | Generic derivation helper mirroring @sqlite-simple@.
 class GFromRow f where

--- a/duckdb-simple/src/Database/DuckDB/Simple/Internal.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Internal.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE StrictData #-}
 
@@ -29,6 +31,8 @@ module Database.DuckDB.Simple.Internal (
     Query (..),
     Connection (..),
     ConnectionState (..),
+    RowParser (..),
+    RowParseRO (..),
     Statement (..),
     StatementState (..),
     StatementStreamState (..),
@@ -55,8 +59,11 @@ module Database.DuckDB.Simple.Internal (
     mkDeleteCallback,
 ) where
 
+import Control.Applicative (Alternative)
 import Control.Exception (Exception, bracket, throwIO)
-import Control.Monad (when)
+import Control.Monad (MonadPlus, when)
+import Control.Monad.Trans.Reader (ReaderT)
+import Control.Monad.Trans.State.Strict (StateT)
 import Data.Array (Array)
 import Data.Bits (Bits (..))
 import qualified Data.ByteString as BS
@@ -100,6 +107,7 @@ import Database.DuckDB.Simple.LogicalRep (
     UnionMemberType (..),
     UnionValue (..),
  )
+import Database.DuckDB.Simple.Ok (Ok)
 import Foreign.C.String (CString)
 import Foreign.Marshal.Alloc (alloca)
 import Foreign.Ptr (Ptr, nullPtr)
@@ -191,6 +199,18 @@ data Field = Field
     , fieldValue :: FieldValue
     }
     deriving (Eq, Show)
+
+-- | Parser used by @FromRow@ implementations.
+newtype RowParser a = RowParser
+    { runRowParser :: ReaderT RowParseRO (StateT (Int, [Field]) Ok) a
+    }
+    deriving stock (Functor)
+    deriving newtype (Applicative, Alternative, Monad, MonadPlus)
+
+-- | Row parsing environment (read-only data available to the parser).
+newtype RowParseRO = RowParseRO
+    { rowParseColumnCount :: Int
+    }
 
 -- | Represents a textual SQL query with UTF-8 encoding semantics.
 newtype Query = Query

--- a/duckdb-simple/src/Database/DuckDB/Simple/Internal.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE StrictData #-}
 
@@ -11,6 +12,19 @@ utilities required by the high-level API.  It is not part of the supported
 public interface; consumers should depend on @Database.DuckDB.Simple@ instead.
 -}
 module Database.DuckDB.Simple.Internal (
+    -- * Field value (to be used by FromField)
+    Field (..),
+    FieldValue (..),
+    StructField (..),
+    StructValue (..),
+    UnionMemberType (..),
+    UnionValue (..),
+    LogicalTypeRep (..),
+    BitString (..),
+    BigNum (..),
+    DecimalValue (..),
+    IntervalValue (..),
+    TimeWithZone (..),
     -- * Data constructors (internal use only)
     Query (..),
     Connection (..),
@@ -43,12 +57,24 @@ module Database.DuckDB.Simple.Internal (
 
 import Control.Exception (Exception, bracket, throwIO)
 import Control.Monad (when)
+import Data.Array (Array)
+import Data.Bits (Bits (..))
+import qualified Data.ByteString as BS
+import Data.Int (Int16, Int32, Int64, Int8)
 import Data.IORef (IORef, readIORef)
 import Data.String (IsString (..))
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Foreign as TextForeign
-import Data.Word (Word64)
+import Data.Time.Calendar (Day)
+import Data.Time.Clock (UTCTime (..))
+import Data.Time.LocalTime (
+    LocalTime (..),
+    TimeOfDay (..),
+    TimeZone (..),
+ )
+import qualified Data.UUID as UUID
+import Data.Word (Word16, Word32, Word64, Word8)
 import Database.DuckDB.FFI (
     DuckDBClientContext,
     DuckDBConnection,
@@ -67,11 +93,104 @@ import Database.DuckDB.FFI (
     c_duckdb_destroy_logical_type,
     c_duckdb_destroy_value,
  )
+import Database.DuckDB.Simple.LogicalRep (
+    LogicalTypeRep (..),
+    StructField (..),
+    StructValue (..),
+    UnionMemberType (..),
+    UnionValue (..),
+ )
 import Foreign.C.String (CString)
 import Foreign.Marshal.Alloc (alloca)
 import Foreign.Ptr (Ptr, nullPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, freeStablePtr)
 import Foreign.Storable (peek, poke)
+
+-- | Internal representation of a column value.
+data FieldValue
+    = FieldNull
+    | FieldInt8 Int8
+    | FieldInt16 Int16
+    | FieldInt32 Int32
+    | FieldInt64 Int64
+    | FieldWord8 Word8
+    | FieldWord16 Word16
+    | FieldWord32 Word32
+    | FieldWord64 Word64
+    | FieldUUID UUID.UUID
+    | FieldFloat Float
+    | FieldDouble Double
+    | FieldText Text
+    | FieldBool Bool
+    | FieldBlob BS.ByteString
+    | FieldDate Day
+    | FieldTime TimeOfDay
+    | FieldTimestamp LocalTime
+    | FieldInterval IntervalValue
+    | FieldHugeInt Integer
+    | FieldUHugeInt Integer
+    | FieldDecimal DecimalValue
+    | FieldTimestampTZ UTCTime
+    | FieldTimeTZ TimeWithZone
+    | FieldBit BitString
+    | FieldBigNum BigNum
+    | FieldEnum Word32
+    | FieldArray (Array Int FieldValue)
+    | FieldList [FieldValue]
+    | FieldMap [(FieldValue, FieldValue)]
+    | FieldStruct (StructValue FieldValue)
+    | FieldUnion (UnionValue FieldValue)
+    deriving (Eq, Show)
+
+-- | Exact-width decimal payload plus its declared width and scale.
+data DecimalValue = DecimalValue
+    { decimalWidth :: !Word8
+    , decimalScale :: !Word8
+    , decimalInteger :: !Integer
+    }
+    deriving (Eq, Show)
+
+-- | DuckDB interval payload split into months, days, and microseconds.
+data IntervalValue = IntervalValue
+    { intervalMonths :: !Int32
+    , intervalDays :: !Int32
+    , intervalMicros :: !Int64
+    }
+    deriving (Eq, Show)
+
+-- | Arbitrary-precision integer wrapper used for DuckDB's BIGNUM type.
+newtype BigNum = BigNum Integer
+    deriving stock (Eq, Show)
+    deriving (Num) via Integer
+
+-- | Time-of-day paired with its associated timezone offset.
+data TimeWithZone = TimeWithZone
+    { timeWithZoneTime :: !TimeOfDay
+    , timeWithZoneZone :: !TimeZone
+    }
+    deriving (Eq, Show)
+
+-- | DuckDB BIT value represented as raw bytes plus left-padding bit count.
+data BitString = BitString
+    { padding :: !Word8
+    , bits :: !BS.ByteString
+    }
+    deriving stock (Eq)
+
+instance Show BitString where
+    show (BitString padding bits) =
+        drop (fromIntegral padding) $ concatMap word8ToString $ BS.unpack bits
+      where
+        word8ToString :: Word8 -> String
+        word8ToString w = map (\n -> if testBit w n then '1' else '0') [7, 6 .. 0]
+
+-- | Metadata for a single column in a row.
+data Field = Field
+    { fieldName :: Text
+    , fieldIndex :: Int
+    , fieldValue :: FieldValue
+    }
+    deriving (Eq, Show)
 
 -- | Represents a textual SQL query with UTF-8 encoding semantics.
 newtype Query = Query


### PR DESCRIPTION
Partially resolves #6. This way, only the datatype will be exported in `FromRow.hs`, keeping the level of intended abstraction, but `beam-duckdb` can access `RowParser` constructor via `Internal.hs`. 

The `Field` datatype also needed to be moved into `Internal.hs` to make it work. 

However, this does not change the fact that removing the constructor from `FromRow.hs` is a breaking change; this PR does not address the issue of broken PVP.

This is probably not the fix you intended but it works for the sake of nixpkgs patches. 

built/tested on NixOS (wsl), GHC 9.12.2 x86-64