### PR TITLE
Appender API

### DIFF
--- a/duckdb-ffi/duckdb-ffi.cabal
+++ b/duckdb-ffi/duckdb-ffi.cabal
@@ -113,6 +113,7 @@ library
     text >=2.0 && <2.2,
     time >=1.12 && <1.16,
     transformers >=0.6 && <0.7,
+    hashable >= 1.5 && < 1.6,
 
   if os(linux)
     ghc-options: "-optl-Wl,-rpath,'$ORIGIN/../cbits/duckdb'"

--- a/duckdb-ffi/src/Database/DuckDB/FFI/Types.hs
+++ b/duckdb-ffi/src/Database/DuckDB/FFI/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StrictData #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module Database.DuckDB.FFI.Types (
     -- * Enumerations
@@ -327,7 +328,7 @@ import Foreign.C.String (CString)
 import Foreign.C.Types
 import Foreign.Ptr (FunPtr, Ptr, nullPtr)
 import Foreign.Storable (Storable (..), peekByteOff, pokeByteOff)
-
+import Data.Hashable
 -- | Unsigned index type used by DuckDB (mirrors @idx_t@).
 type DuckDBIdx = Word64
 
@@ -348,6 +349,8 @@ pattern DuckDBError = DuckDBState 1
 -- | DuckDB primitive physical type identifiers (mirrors @duckdb_type@).
 newtype DuckDBType = DuckDBType {unDuckDBType :: CInt}
     deriving (Eq, Ord, Show, Storable)
+instance Hashable DuckDBType where
+    hashWithSalt s (DuckDBType v) = hashWithSalt s (fromIntegral @_ @Int v)
 
 -- | Pattern synonyms for DuckDB's physical value type tags.
 pattern

--- a/duckdb-simple/duckdb-simple.cabal
+++ b/duckdb-simple/duckdb-simple.cabal
@@ -37,6 +37,8 @@ source-repository head
 library
   exposed-modules:
     Database.DuckDB.Simple
+    Database.DuckDB.Simple.Appender
+    Database.DuckDB.Simple.Appender.Generic
     Database.DuckDB.Simple.Catalog
     Database.DuckDB.Simple.Config
     Database.DuckDB.Simple.Copy
@@ -46,6 +48,7 @@ library
     Database.DuckDB.Simple.Function
     Database.DuckDB.Simple.Generic
     Database.DuckDB.Simple.Internal
+    Database.DuckDB.Simple.Internal.ValueHelpers
     Database.DuckDB.Simple.Logging
     Database.DuckDB.Simple.LogicalRep
     Database.DuckDB.Simple.Ok
@@ -59,6 +62,7 @@ library
   hs-source-dirs: src
   default-language: Haskell2010
   build-depends:
+    aeson >= 2.2 && < 2.3,
     array >=0.5 && <0.6,
     base >=4.14 && <5,
     bytestring >=0.11 && <0.13,
@@ -68,14 +72,17 @@ library
     time >=1.12 && <1.16,
     transformers >=0.6 && <0.7,
     uuid >=1.3 && <1.4,
+    unordered-containers >= 0.2 && < 0.3,
+    hashable >= 1.5 && < 1.6,
 
 test-suite duckdb-simple-test
   type: exitcode-stdio-1.0
   hs-source-dirs: test
   main-is: Spec.hs
-  other-modules: Properties
+  other-modules: Properties Appender
   default-language: Haskell2010
   build-depends:
+    aeson >=2.2 && < 2.3,
     QuickCheck >=2.14 && <2.16,
     array >=0.5 && <0.6,
     base >=4.14 && <5,

--- a/duckdb-simple/duckdb-simple.cabal
+++ b/duckdb-simple/duckdb-simple.cabal
@@ -75,6 +75,7 @@ library
     unordered-containers >= 0.2 && < 0.3,
     hashable >= 1.5 && < 1.6,
     scientific >= 0.3.8 && < 0.3.9,
+    vector
 
 test-suite duckdb-simple-test
   type: exitcode-stdio-1.0

--- a/duckdb-simple/duckdb-simple.cabal
+++ b/duckdb-simple/duckdb-simple.cabal
@@ -74,6 +74,7 @@ library
     uuid >=1.3 && <1.4,
     unordered-containers >= 0.2 && < 0.3,
     hashable >= 1.5 && < 1.6,
+    scientific >= 0.3.8 && < 0.3.9,
 
 test-suite duckdb-simple-test
   type: exitcode-stdio-1.0

--- a/duckdb-simple/duckdb-simple.cabal
+++ b/duckdb-simple/duckdb-simple.cabal
@@ -62,7 +62,7 @@ library
   hs-source-dirs: src
   default-language: Haskell2010
   build-depends:
-    aeson >= 2.2 && < 2.3,
+    aeson >= 2.2 && < 2.4,
     array >=0.5 && <0.6,
     base >=4.14 && <5,
     bytestring >=0.11 && <0.13,
@@ -84,7 +84,7 @@ test-suite duckdb-simple-test
   other-modules: Properties Appender
   default-language: Haskell2010
   build-depends:
-    aeson >=2.2 && < 2.3,
+    aeson >=2.2 && < 2.4,
     QuickCheck >=2.14 && <2.16,
     array >=0.5 && <0.6,
     base >=4.14 && <5,

--- a/duckdb-simple/src/Database/DuckDB/Simple.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple.hs
@@ -19,6 +19,7 @@ module Database.DuckDB.Simple (
     close,
     withConnection,
     withConnectionWithConfig,
+    DuckDBDatabase,
 
     -- * Queries and statements
     Query (..),
@@ -76,6 +77,8 @@ module Database.DuckDB.Simple (
     createFunction,
     createFunctionWithState,
     deleteFunction,
+    withDatabase,
+    withDatabaseConnection,
 ) where
 
 import Control.Exception (SomeException, bracket, finally, mask, onException, throwIO, try)
@@ -129,6 +132,7 @@ import Foreign.C.String (CString, peekCString, withCString)
 import Foreign.Marshal.Alloc (alloca, free, malloc)
 import Foreign.Ptr (Ptr, castPtr, nullPtr)
 import Foreign.Storable (peek, poke)
+import GHC.Stack (HasCallStack, callStack)
 
 -- | Open a DuckDB database located at the supplied path.
 open :: FilePath -> IO Connection
@@ -156,9 +160,24 @@ close Connection{connectionState} =
             openState@(ConnectionOpen{}) ->
                 (ConnectionClosed, closeHandles openState)
 
+closeConnection :: Connection -> IO ()
+closeConnection Connection{connectionState} =
+    void $
+        atomicModifyIORef' connectionState \case
+            ConnectionClosed -> (ConnectionClosed, pure ())
+            ConnectionOpen{connectionHandle} ->
+                (ConnectionClosed, closeConnectionHandle connectionHandle)
+
+
 -- | Run an action with a freshly opened connection, closing it afterwards.
 withConnection :: FilePath -> (Connection -> IO a) -> IO a
 withConnection path = bracket (open path) close
+
+withDatabase :: FilePath -> [(Text, Text)] -> (DuckDBDatabase -> IO a) -> IO a
+withDatabase path opts = bracket (openDatabaseWithConfig path opts) closeDatabaseHandle
+
+withDatabaseConnection :: DuckDBDatabase -> (Connection -> IO a) -> IO a
+withDatabaseConnection db = bracket (connectDatabase db >>= createConnection db) closeConnection
 
 -- | Run an action with a freshly opened configured connection, closing it afterwards.
 withConnectionWithConfig :: FilePath -> [(Text, Text)] -> (Connection -> IO a) -> IO a
@@ -681,7 +700,7 @@ destroyDataChunk chunk =
         poke ptr chunk
         c_duckdb_destroy_data_chunk ptr
 
-streamingUnsupportedTypeError :: Query -> StatementStreamColumn -> SQLError
+streamingUnsupportedTypeError :: HasCallStack => Query -> StatementStreamColumn -> SQLError
 streamingUnsupportedTypeError queryText StatementStreamColumn{statementStreamColumnName, statementStreamColumnType} =
     SQLError
         { sqlErrorMessage =
@@ -693,6 +712,7 @@ streamingUnsupportedTypeError queryText StatementStreamColumn{statementStreamCol
                 ]
         , sqlErrorType = Nothing
         , sqlErrorQuery = Just queryText
+        , sqlErrorCallStack = callStack
         }
 
 -- | Run an action inside a transaction.
@@ -832,36 +852,40 @@ fetchResultError resultPtr = do
                 else Just errType
     pure (msg, classified)
 
-mkOpenError :: Text -> SQLError
+mkOpenError :: HasCallStack => Text -> SQLError
 mkOpenError msg =
     SQLError
         { sqlErrorMessage = msg
         , sqlErrorType = Nothing
         , sqlErrorQuery = Nothing
+        , sqlErrorCallStack = callStack
         }
 
-mkConnectError :: SQLError
+mkConnectError :: HasCallStack => SQLError
 mkConnectError =
     SQLError
         { sqlErrorMessage = Text.pack "duckdb-simple: failed to create connection handle"
         , sqlErrorType = Nothing
         , sqlErrorQuery = Nothing
+        , sqlErrorCallStack = callStack
         }
 
-mkPrepareError :: Query -> Text -> SQLError
+mkPrepareError :: HasCallStack => Query -> Text -> SQLError
 mkPrepareError queryText msg =
     SQLError
         { sqlErrorMessage = msg
         , sqlErrorType = Nothing
         , sqlErrorQuery = Just queryText
+        , sqlErrorCallStack = callStack
         }
 
-mkExecuteError :: Query -> Text -> Maybe DuckDBErrorType -> SQLError
+mkExecuteError :: HasCallStack => Query -> Text -> Maybe DuckDBErrorType -> SQLError
 mkExecuteError queryText msg errType =
     SQLError
         { sqlErrorMessage = msg
         , sqlErrorType = errType
         , sqlErrorQuery = Just queryText
+        , sqlErrorCallStack = callStack
         }
 
 throwFormatError :: Statement -> Text -> [String] -> IO a
@@ -906,6 +930,7 @@ columnIndexError stmt idx total =
             { sqlErrorMessage = message
             , sqlErrorType = Nothing
             , sqlErrorQuery = Just (statementQuery stmt)
+            , sqlErrorCallStack = callStack
             }
 
 columnNameUnavailableError :: Statement -> Int -> SQLError
@@ -918,6 +943,7 @@ columnNameUnavailableError stmt idx =
                 ]
         , sqlErrorType = Nothing
         , sqlErrorQuery = Just (statementQuery stmt)
+        , sqlErrorCallStack = callStack
         }
 
 normalizeName :: Text -> Text

--- a/duckdb-simple/src/Database/DuckDB/Simple/Appender.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Appender.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -22,7 +21,7 @@ module Database.DuckDB.Simple.Appender
   )
   where
 
-import Database.DuckDB.FFI    (c_duckdb_appender_error_data, c_duckdb_error_data_message, DuckDBAppender,      DuckDBLogicalType,      DuckDBState,      pattern DuckDBSuccess,      pattern DuckDBError,      c_duckdb_appender_create,      c_duckdb_appender_create_ext,      c_duckdb_appender_create_query,      c_duckdb_appender_destroy, c_duckdb_appender_begin_row, c_duckdb_appender_end_row, c_duckdb_appender_flush, c_duckdb_appender_close )
+import Database.DuckDB.FFI    (DuckDBAppender,      DuckDBLogicalType,      DuckDBState,      pattern DuckDBSuccess,      pattern DuckDBError,      c_duckdb_appender_create,      c_duckdb_appender_create_ext,      c_duckdb_appender_create_query,      c_duckdb_appender_destroy, c_duckdb_appender_begin_row, c_duckdb_appender_end_row, c_duckdb_appender_flush, c_duckdb_appender_close )
 import Data.Text.Foreign (withCString)
 import Data.Text (Text)
 import Foreign (Ptr, nullPtr, Storable (peek))
@@ -30,12 +29,11 @@ import Foreign.Marshal.Alloc (alloca)
 import Foreign.Marshal.Array (withArray)
 import Control.Exception (finally, throwIO)
 import Control.Monad (when)
-import Database.DuckDB.Simple.Internal (withConnectionHandle, Connection, SQLError(..), Query(..))
+import Database.DuckDB.Simple.Internal (withConnectionHandle, Connection, Query(..))
 import GHC.Stack (HasCallStack)
 import Data.Data (Proxy)
 import qualified Data.Text as Text
 import Database.DuckDB.Simple.Appender.Generic
-import Foreign.C (peekCString)
 
 type TableName = Text
 
@@ -80,16 +78,8 @@ withAppenderAcquire acquire action =
 appendTableRow :: (HasCallStack, AppendTableRow a) => DuckDBAppender -> a -> IO ()
 appendTableRow app row = do
     assertSuccess app $ c_duckdb_appender_begin_row app
-    assertSuccess app $ appendDuckRow app row
+    appendDuckRow app row
     assertSuccess app $ c_duckdb_appender_end_row app
-
-assertSuccess :: (HasCallStack) => DuckDBAppender -> IO DuckDBState -> IO ()
-assertSuccess app f = f >>= \case
-  DuckDBSuccess -> pure ()
-  _errorStatus -> do
-        err <- c_duckdb_appender_error_data app >>= c_duckdb_error_data_message >>= peekCString
-        throwIO $ SQLError("duckdb-simple: appender error" <> Text.pack err) Nothing Nothing -- FIXME: proper error handling
-{-# INLINE assertSuccess #-}
 
 createTableQuery :: AppendTableRow a => Text -> Proxy a -> Query
 createTableQuery nme pxy = Query $ "CREATE TABLE \"" <> nme <> "\" (" <> tableSchema pxy <> ")" -- FIXME: unsafe

--- a/duckdb-simple/src/Database/DuckDB/Simple/Appender.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Appender.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+{- |
+Module      : Database.DuckDB.Simple.Appender
+Description : High-performance appender API
+-}
+module Database.DuckDB.Simple.Appender
+  ( withTableAppender
+  , withTableAppenderExt
+  , withQueryAppender
+  , appendTableRow
+  , tableSchema
+  , createTableQuery
+  , module Database.DuckDB.Simple.Appender.Generic
+  )
+  where
+
+import Database.DuckDB.FFI    (c_duckdb_appender_error_data, c_duckdb_error_data_message, DuckDBAppender,      DuckDBLogicalType,      DuckDBState,      pattern DuckDBSuccess,      pattern DuckDBError,      c_duckdb_appender_create,      c_duckdb_appender_create_ext,      c_duckdb_appender_create_query,      c_duckdb_appender_destroy, c_duckdb_appender_begin_row, c_duckdb_appender_end_row, c_duckdb_appender_flush, c_duckdb_appender_close )
+import Data.Text.Foreign (withCString)
+import Data.Text (Text)
+import Foreign (Ptr, nullPtr, Storable (peek))
+import Foreign.Marshal.Alloc (alloca)
+import Foreign.Marshal.Array (withArray)
+import Control.Exception (finally, throwIO)
+import Control.Monad (when)
+import Database.DuckDB.Simple.Internal (withConnectionHandle, Connection, SQLError(..), Query(..))
+import GHC.Stack (HasCallStack)
+import Data.Data (Proxy)
+import qualified Data.Text as Text
+import Database.DuckDB.Simple.Appender.Generic
+import Foreign.C (peekCString)
+
+type TableName = Text
+
+withTableAppender :: Connection -> TableName -> (DuckDBAppender -> IO a) -> IO a
+withTableAppender conn tableName action = withConnectionHandle conn $ \conn' ->
+    withCString tableName $ \tablePtr ->
+        withAppenderAcquire
+            (c_duckdb_appender_create conn' nullPtr tablePtr)
+            action
+
+withTableAppenderExt :: Connection -> TableName -> (DuckDBAppender -> IO a) -> IO a
+withTableAppenderExt conn tableName action = withConnectionHandle conn $ \conn' ->
+    withCString tableName $ \tablePtr ->
+        withAppenderAcquire
+            (c_duckdb_appender_create_ext conn' nullPtr nullPtr tablePtr)
+            action
+
+withQueryAppender :: Connection -> TableName -> [DuckDBLogicalType] -> (DuckDBAppender -> IO a) -> IO a
+withQueryAppender conn query types action = withConnectionHandle conn $ \conn' ->
+    withCString query $ \queryPtr ->
+        withArray types $ \typeArray ->
+            withAppenderAcquire
+                (c_duckdb_appender_create_query conn' queryPtr (fromIntegral (length types)) typeArray nullPtr nullPtr)
+                action
+
+withAppenderAcquire :: (Ptr DuckDBAppender -> IO DuckDBState) -> (DuckDBAppender -> IO a) -> IO a
+withAppenderAcquire acquire action =
+    alloca $ \appPtr -> do
+        state <- acquire appPtr
+        when (state /= DuckDBSuccess) $ throwIO (userError "duckdb-simple: could not acquire appender")
+        case state of
+          DuckDBSuccess -> pure ()
+          DuckDBError -> throwIO (userError "withAppenderAcquire")
+        app <- peek appPtr
+        let release = do
+              assertSuccess app $ c_duckdb_appender_destroy appPtr
+            flushAndClose = do
+                assertSuccess app $ c_duckdb_appender_flush app
+                assertSuccess app $ c_duckdb_appender_close app
+        (action app <* flushAndClose) `finally` release
+
+appendTableRow :: (HasCallStack, AppendTableRow a) => DuckDBAppender -> a -> IO ()
+appendTableRow app row = do
+    assertSuccess app $ c_duckdb_appender_begin_row app
+    assertSuccess app $ appendDuckRow app row
+    assertSuccess app $ c_duckdb_appender_end_row app
+
+assertSuccess :: (HasCallStack) => DuckDBAppender -> IO DuckDBState -> IO ()
+assertSuccess app f = f >>= \case
+  DuckDBSuccess -> pure ()
+  _errorStatus -> do
+        err <- c_duckdb_appender_error_data app >>= c_duckdb_error_data_message >>= peekCString
+        throwIO $ SQLError("duckdb-simple: appender error" <> Text.pack err) Nothing Nothing -- FIXME: proper error handling
+{-# INLINE assertSuccess #-}
+
+createTableQuery :: AppendTableRow a => Text -> Proxy a -> Query
+createTableQuery nme pxy = Query $ "CREATE TABLE \"" <> nme <> "\" (" <> tableSchema pxy <> ")" -- FIXME: unsafe
+
+tableSchema :: (AppendTableRow a) => Proxy a -> Text
+tableSchema pxy = Text.intercalate ", \n" ["\"" <> structFieldName <> "\" " <> renderDuckTypeName structFieldValue | (structFieldName, structFieldValue) <- appendDuckRowSchema pxy]

--- a/duckdb-simple/src/Database/DuckDB/Simple/Appender.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Appender.hs
@@ -95,4 +95,4 @@ createTableQuery :: AppendTableRow a => Text -> Proxy a -> Query
 createTableQuery nme pxy = Query $ "CREATE TABLE \"" <> nme <> "\" (" <> tableSchema pxy <> ")" -- FIXME: unsafe
 
 tableSchema :: (AppendTableRow a) => Proxy a -> Text
-tableSchema pxy = Text.intercalate ", \n" ["\"" <> structFieldName <> "\" " <> renderDuckTypeName structFieldValue | (structFieldName, structFieldValue) <- appendDuckRowSchema pxy]
+tableSchema pxy = Text.intercalate ", \n" ["\"" <> nme <> "\" " <> renderDuckTypeName tpe | (nme, tpe) <- appendDuckRowSchema pxy]

--- a/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
@@ -77,7 +77,7 @@ import Database.DuckDB.FFI
 import Database.DuckDB.Simple.FromField (BigNum (..), IntervalValue (..), TimeWithZone (..))
 import Database.DuckDB.Simple.Internal
 import Database.DuckDB.Simple.Internal.ValueHelpers
-import Debug.Trace (trace, traceIO)
+import Data.Scientific (Scientific)
 
 newtype Allocated a = Allocated {allocate :: IO a}
 
@@ -220,6 +220,12 @@ instance AppenderDuckValue Double where
     appenderDuckValue = Allocated . doubleDuckValue
     appenderLogicalTypeUncached _ = primitiveType DuckDBTypeDouble
     appendDuckValue app = c_duckdb_append_double app . CDouble
+    appenderTypeName _ = "DOUBLE"
+
+instance AppenderDuckValue Scientific where
+    appenderDuckValue = Allocated . doubleDuckValue . realToFrac
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeDouble
+    appendDuckValue app = c_duckdb_append_double app . CDouble . realToFrac
     appenderTypeName _ = "DOUBLE"
 
 instance AppenderDuckValue Text where

--- a/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
@@ -27,6 +27,14 @@ module Database.DuckDB.Simple.Appender.Generic (
     ViaDuckEnum (..),
     AppendTableRow (..),
     DuckTypeName (..),
+    appenderLogicalType,
+    cacheAppenderLogicalType,
+    DuckStructField(..),
+    duckStructLogicalType,
+    duckStructTypeName,
+    duckStructValue,
+    Allocated(..),
+    DuckDBValue
 ) where
 
 import Control.Monad (join, (>=>))
@@ -335,43 +343,49 @@ instance (Ord k, AppenderDuckValue k, AppenderDuckValue v, Typeable k, Typeable 
 newtype ViaDuckStruct a = ViaDuckStruct a
 
 instance (Typeable a, GDuckStruct (Rep a), Generic a) => AppenderDuckValue (ViaDuckStruct a) where
-    appenderDuckValue (ViaDuckStruct v) = Allocated $ do
-        structType <- cacheAppenderLogicalType (typeRep $ Proxy @a) (gstructTypeIO $ gstructType $ Proxy @(Rep a))
-        withManyAllocated (gstructValue $ from v) $ \childValues ->
-            withArray childValues $ c_duckdb_create_struct_value structType
+    appenderDuckValue (ViaDuckStruct v) = duckStructValue (cacheAppenderLogicalType (typeRep $ Proxy @a) (duckStructLogicalType $ gstructType $ Proxy @(Rep a))) (gstructValue $ from v)
 
-    appenderLogicalTypeUncached _ = gstructTypeIO $ gstructType $ Proxy @(Rep a)
+    appenderLogicalTypeUncached _ = duckStructLogicalType $ gstructType $ Proxy @(Rep a)
 
-    appenderTypeName _ = gstructTypeName "STRUCT" $ gstructType $ Proxy @(Rep a)
+    appenderTypeName _ = duckStructTypeName $ gstructType $ Proxy @(Rep a)
 
-data GDuckStructField = GDuckStructField {gname :: Text, _gtypeName :: DuckTypeName, glogicalType :: IO DuckDBLogicalType}
+data DuckStructField = DuckStructField {structFieldName :: Text, structFieldType :: DuckTypeName, structLogicalType :: IO DuckDBLogicalType}
 
-gstructTypeIO :: [GDuckStructField] -> Uncached DuckDBLogicalType
-gstructTypeIO flds = Uncached $ do
-    evaluatedTypes <- mapM glogicalType flds
-    withMany Text.withCString (gname <$> flds) $ \namePtrs ->
+duckStructValue :: IO DuckDBLogicalType -> [Allocated DuckDBValue] -> Allocated DuckDBValue
+duckStructValue getType vals = Allocated $ do
+    structType <- getType
+    withManyAllocated vals $ \childValues ->
+        withArray childValues $ c_duckdb_create_struct_value structType
+
+duckStructLogicalType :: [DuckStructField] -> Uncached DuckDBLogicalType
+duckStructLogicalType flds = Uncached $ do
+    evaluatedTypes <- mapM structLogicalType flds
+    withMany Text.withCString (structFieldName <$> flds) $ \namePtrs ->
         withArray namePtrs $ \nameArray ->
             withArray evaluatedTypes $ \typeArray ->
                 c_duckdb_create_struct_type typeArray nameArray (fromIntegral $ length flds)
 
-gunionTypeLogical :: [GDuckStructField] -> Uncached DuckDBLogicalType
+gunionTypeLogical :: [DuckStructField] -> Uncached DuckDBLogicalType
 gunionTypeLogical flds = Uncached $ do
-    evaluatedTypes <- mapM glogicalType flds
-    withMany Text.withCString (gname <$> flds) $ \namePtrs ->
+    evaluatedTypes <- mapM structLogicalType flds
+    withMany Text.withCString (structFieldName <$> flds) $ \namePtrs ->
         withArray namePtrs $ \nameArray ->
             withArray evaluatedTypes $ \typeArray ->
                 c_duckdb_create_union_type typeArray nameArray (fromIntegral $ length flds)
 
-gstructTypeName :: Text -> [GDuckStructField] -> DuckTypeName
-gstructTypeName pfx flds = DuckTypeName $ pfx <> "(" <> Text.intercalate ", " ["\"" <> nme <> "\" " <> renderDuckTypeName tpeNme | GDuckStructField nme tpeNme _ <- flds] <> ")"
+duckStructTypeName :: [DuckStructField] -> DuckTypeName
+duckStructTypeName = gstructTypeName "STRUCT"
+
+gstructTypeName :: Text -> [DuckStructField] -> DuckTypeName
+gstructTypeName pfx flds = DuckTypeName $ pfx <> "(" <> Text.intercalate ", " ["\"" <> nme <> "\" " <> renderDuckTypeName tpeNme | DuckStructField nme tpeNme _ <- flds] <> ")"
 
 class GDuckStruct (f :: Type -> Type) where
     gstructValue :: f b -> [Allocated DuckDBValue]
-    gstructType :: Proxy f -> [GDuckStructField]
+    gstructType :: Proxy f -> [DuckStructField]
 
 instance (AppenderDuckValue a, KnownSymbol selectorName, Typeable a) => GDuckStruct (S1 ('MetaSel ('Just selectorName) q w e) (K1 i a)) where
     gstructValue (M1 (K1 v)) = pure $ appenderDuckValue v
-    gstructType _ = pure $ GDuckStructField (Text.pack $ symbolVal (Proxy @selectorName)) (appenderTypeName (Proxy @a)) (appenderLogicalType (Proxy @a))
+    gstructType _ = pure $ DuckStructField (Text.pack $ symbolVal (Proxy @selectorName)) (appenderTypeName (Proxy @a)) (appenderLogicalType (Proxy @a))
 
 instance (GDuckStruct a, GDuckStruct b) => GDuckStruct (a :*: b) where
     gstructValue (a :*: b) = gstructValue a <> gstructValue b
@@ -406,7 +420,7 @@ instance (Typeable a, GDuckUnion (Rep a), Generic a) => AppenderDuckValue (ViaDu
 
 class GDuckUnion (f :: Type -> Type) where
     gunionValue :: (Typeable root) => Proxy root -> Word -> f b -> (Word, Allocated DuckDBValue)
-    gunionType :: (Typeable root) => Proxy root -> Proxy f -> [GDuckStructField]
+    gunionType :: (Typeable root) => Proxy root -> Proxy f -> [DuckStructField]
 
 data Tople (a :: Type) (b :: Symbol)
 
@@ -417,18 +431,18 @@ instance (GDuckUnion a, GDuckUnion b) => GDuckUnion (a :+: b) where
 
 instance {-# OVERLAPPABLE #-} (KnownSymbol conName) => GDuckUnion (C1 ('MetaCons conName foo bar) U1) where
     gunionValue (_ :: Proxy root) ix (M1 _) = (ix, Allocated nullDuckValue)
-    gunionType _root _ = [GDuckStructField (Text.pack $ symbolVal (Proxy @conName)) "TINYINT" (appenderLogicalType (Proxy @Int8))]
+    gunionType _root _ = [DuckStructField (Text.pack $ symbolVal (Proxy @conName)) "TINYINT" (appenderLogicalType (Proxy @Int8))]
 
 instance {-# OVERLAPPABLE #-} (KnownSymbol conName, Typeable a, AppenderDuckValue a) => GDuckUnion (C1 ('MetaCons conName foo bar) (S1 ms (Rec0 a))) where
     gunionValue (_ :: Proxy root) ix (M1 _) = (ix, Allocated nullDuckValue)
-    gunionType _root _ = [GDuckStructField (Text.pack $ symbolVal (Proxy @conName)) (appenderTypeName (Proxy @a)) (appenderLogicalType (Proxy @a))]
+    gunionType _root _ = [DuckStructField (Text.pack $ symbolVal (Proxy @conName)) (appenderTypeName (Proxy @a)) (appenderLogicalType (Proxy @a))]
 
 instance {-# OVERLAPS #-} (GDuckStruct a, KnownSymbol conName) => GDuckUnion (C1 ('MetaCons conName foo bar) a) where
     gunionValue (_ :: Proxy root) ix (M1 v) = (ix,) $ Allocated $ do
-        structType <- cacheAppenderLogicalType (typeRep $ Proxy @(Tople root conName)) (gstructTypeIO $ gstructType $ Proxy @a)
+        structType <- cacheAppenderLogicalType (typeRep $ Proxy @(Tople root conName)) (duckStructLogicalType $ gstructType $ Proxy @a)
         withManyAllocated (gstructValue v) $ \childValues ->
             withArray childValues $ c_duckdb_create_struct_value structType
-    gunionType (_ :: Proxy root) _ = [GDuckStructField (Text.pack $ symbolVal (Proxy @conName)) (gstructTypeName "STRUCT" t) (cacheAppenderLogicalType (typeRep $ Proxy @(Tople root conName)) $ gstructTypeIO t)]
+    gunionType (_ :: Proxy root) _ = [DuckStructField (Text.pack $ symbolVal (Proxy @conName)) (gstructTypeName "STRUCT" t) (cacheAppenderLogicalType (typeRep $ Proxy @(Tople root conName)) $ duckStructLogicalType t)]
       where
         t = gstructType $ Proxy @a
 

--- a/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
@@ -83,7 +83,10 @@ import Data.Scientific (Scientific)
 import GHC.Stack (HasCallStack)
 import Foreign.C (peekCString)
 import Data.Bifunctor (first)
-import Debug.Trace (traceShowWith)
+import qualified Data.Vector.Mutable as VM
+import Data.Bits (unsafeShiftR)
+import qualified Data.Vector as V
+import Control.Monad.ST
 
 newtype Allocated a = Allocated {allocate :: IO a}
 
@@ -300,12 +303,14 @@ instance AppenderDuckValue TimeWithZone where
 instance (AppenderDuckValue a) => AppenderDuckValue (Maybe a) where
     appenderDuckValue (Just x) = appenderDuckValue x
     appenderDuckValue Nothing = Allocated nullDuckValue
+    {-# INLINE appenderDuckValue #-}
     appenderLogicalTypeUncached _ = appenderLogicalTypeUncached (Proxy :: Proxy a)
     appendDuckValue app = maybe (c_duckdb_append_null app) (appendDuckValue app)
     appenderTypeName _ = appenderTypeName (Proxy @a)
 
 instance (AppenderDuckValue a, Typeable a) => AppenderDuckValue [a] where
     appenderDuckValue = arrayDuckValue
+    {-# INLINE appenderDuckValue #-}
     appenderLogicalTypeUncached _ = Uncached $ appenderLogicalType (Proxy @a) >>= c_duckdb_create_list_type
     appenderTypeName _ = appenderTypeName (Proxy @a) <> "[]"
 
@@ -348,10 +353,9 @@ instance AppenderDuckValue Aeson.Value where
 instance (Ord k, AppenderDuckValue k, AppenderDuckValue v, Typeable k, Typeable v) => AppenderDuckValue (Map.Map k v) where
     appenderDuckValue m = Allocated $ do
         mapType <- appenderLogicalType (Proxy @(Map k v))
-        let elemsList = Map.toList m
-            count = length elemsList
-        withManyAllocated (appenderDuckValue . fst <$> elemsList) $ \keys ->
-            withManyAllocated (appenderDuckValue . snd <$> elemsList) $ \values ->
+        let count = Map.size m
+        withManyAllocated (appenderDuckValue <$> Map.keys m) $ \keys ->
+            withManyAllocated (appenderDuckValue <$> Map.elems m) $ \values ->
                 withArray keys \ptrK ->
                     withArray values \ptrV -> c_duckdb_create_map_value mapType ptrK ptrV (fromIntegral count)
 
@@ -362,7 +366,7 @@ instance (Ord k, AppenderDuckValue k, AppenderDuckValue v, Typeable k, Typeable 
 
 newtype ViaDuckStruct a = ViaDuckStruct a
 
-instance (Typeable a, GDuckStruct (Rep a), Generic a) => AppenderDuckValue (ViaDuckStruct a) where
+instance (Typeable a, GDuckStruct (Rep a), Generic a, GDuckStructType (Rep a)) => AppenderDuckValue (ViaDuckStruct a) where
     appenderDuckValue (ViaDuckStruct v) = duckStructValue (cacheAppenderLogicalType (typeRep $ Proxy @a) (duckStructLogicalType $ gstructType $ Proxy @(Rep a))) (gstructValue $ from v)
 
     appenderLogicalTypeUncached _ = duckStructLogicalType $ gstructType $ Proxy @(Rep a)
@@ -371,11 +375,11 @@ instance (Typeable a, GDuckStruct (Rep a), Generic a) => AppenderDuckValue (ViaD
 
 data DuckStructField = DuckStructField {structFieldName :: Text, structFieldType :: DuckTypeName, structLogicalType :: IO DuckDBLogicalType}
 
-duckStructValue :: IO DuckDBLogicalType -> [Allocated DuckDBValue] -> Allocated DuckDBValue
+duckStructValue :: IO DuckDBLogicalType -> V.Vector (Allocated DuckDBValue) -> Allocated DuckDBValue
 duckStructValue getType vals = Allocated $ do
     structType <- getType
     withManyAllocated vals $ \childValues ->
-        withArray childValues $ c_duckdb_create_struct_value structType
+        withArray (V.toList childValues) $ c_duckdb_create_struct_value structType
 
 duckStructLogicalType :: [DuckStructField] -> Uncached DuckDBLogicalType
 duckStructLogicalType flds = Uncached $ do
@@ -400,23 +404,68 @@ gstructTypeName :: Text -> [DuckStructField] -> DuckTypeName
 gstructTypeName pfx flds = DuckTypeName $ pfx <> "(" <> Text.intercalate ", " ["\"" <> nme <> "\" " <> renderDuckTypeName tpeNme | DuckStructField nme tpeNme _ <- flds] <> ")"
 
 class GDuckStruct (f :: Type -> Type) where
-    gstructValue :: f b -> [Allocated DuckDBValue]
-    gstructType :: Proxy f -> [DuckStructField]
+    gstructValue :: f b -> V.Vector (Allocated DuckDBValue)
 
 instance (AppenderDuckValue a, KnownSymbol selectorName, Typeable a) => GDuckStruct (S1 ('MetaSel ('Just selectorName) q w e) (K1 i a)) where
-    gstructValue (M1 (K1 v)) = pure $ appenderDuckValue v
-    gstructType _ = pure $ DuckStructField (Text.pack $ symbolVal (Proxy @selectorName)) (appenderTypeName (Proxy @a)) (appenderLogicalType (Proxy @a))
+    gstructValue (M1 (K1 v)) = V.singleton $ appenderDuckValue v
+    {-# INLINE gstructValue #-}
 
-instance (GDuckStruct a, GDuckStruct b) => GDuckStruct (a :*: b) where
-    gstructValue (a :*: b) = gstructValue a <> gstructValue b
-    gstructType _ = gstructType (Proxy @a) <> gstructType (Proxy @b)
+instance (WriteProduct a, WriteProduct b, ProductSize a, ProductSize b) => GDuckStruct (a :*: b) where
+    gstructValue p =
+         V.create $ do
+          mv <- VM.unsafeNew lenProduct
+          writeProduct mv 0 lenProduct p
+          pure mv
+        where
+          lenProduct = productSize (Proxy @(a :*: b))
+    {-# INLINE gstructValue #-}
 
 instance (GDuckStruct a) => GDuckStruct (M1 C c a) where
     gstructValue (M1 v) = gstructValue v
-    gstructType _ = gstructType (Proxy @a)
+    {-# INLINE gstructValue #-}
 
 instance (GDuckStruct a) => GDuckStruct (M1 D c a) where
     gstructValue (M1 v) = gstructValue v
+
+class ProductSize (f :: Type -> Type) where
+    productSize :: Proxy f -> Int
+
+instance (ProductSize a, ProductSize b) => ProductSize (a :*: b) where
+    productSize _ = productSize (Proxy @a) + productSize (Proxy @b)
+
+instance ProductSize (S1 s a) where
+    productSize _ = 1
+
+class WriteProduct f where
+    writeProduct :: VM.MVector s (Allocated DuckDBValue) -> Int -> Int -> f a -> ST s ()
+
+instance (WriteProduct a, WriteProduct b) => WriteProduct (a :*: b) where
+    writeProduct  mv ix len (a :*: b) = do
+      writeProduct  mv ix  lenL a
+      writeProduct  mv ixR lenR b
+        where
+          lenL = len `unsafeShiftR` 1
+          lenR = len - lenL
+          ixR  = ix  + lenL
+    {-# INLINE writeProduct #-}
+
+instance (AppenderDuckValue a) => WriteProduct (S1 meta (K1 i a)) where
+    writeProduct mv ix _ (M1 (K1 val)) = VM.unsafeWrite mv ix (appenderDuckValue val)
+    {-# INLINE writeProduct #-}
+
+class GDuckStructType (f :: Type -> Type) where
+    gstructType :: Proxy f -> [DuckStructField]
+
+instance (AppenderDuckValue a, KnownSymbol selectorName, Typeable a) => GDuckStructType (S1 ('MetaSel ('Just selectorName) q w e) (K1 i a)) where
+    gstructType _ = pure $ DuckStructField (Text.pack $ symbolVal (Proxy @selectorName)) (appenderTypeName (Proxy @a)) (appenderLogicalType (Proxy @a))
+
+instance (GDuckStructType a, GDuckStructType b) => GDuckStructType (a :*: b) where
+    gstructType _ = gstructType (Proxy @a) <> gstructType (Proxy @b)
+
+instance (GDuckStructType a) => GDuckStructType (M1 C c a) where
+    gstructType _ = gstructType (Proxy @a)
+
+instance (GDuckStructType a) => GDuckStructType (M1 D c a) where
     gstructType _ = gstructType (Proxy @a)
 
 --
@@ -426,7 +475,7 @@ newtype ViaDuckUnion a = ViaDuckUnion a
 instance (Typeable a, GDuckUnion (Rep a), Generic a) => AppenderDuckValue (ViaDuckUnion a) where
     appenderDuckValue (ViaDuckUnion v) = Allocated $ do
         unionType <- cacheAppenderLogicalType (typeRep $ Proxy @a) (gunionTypeLogical $ gunionType (Proxy @a) (Proxy @(Rep a)))
-        let (ix, valueIO) = traceShowWith fst $ gunionValue (Proxy @a) $ from v
+        let (ix, valueIO) = gunionValue (Proxy @a) $ from v
         withAllocated valueIO $ c_duckdb_create_union_value unionType ix
     appenderLogicalTypeUncached _ = gunionTypeLogical $ gunionType (Proxy @a) $ Proxy @(Rep a)
 
@@ -441,27 +490,32 @@ data Tople (a :: Type) (b :: Symbol)
 instance (GDuckUnion a, GDuckUnion b, GConstructorCount a) => GDuckUnion (a :+: b) where
     gunionValue root (L1 l) = gunionValue root l
     gunionValue root (R1 r) = first (+ gconstructorCount  (Proxy @a)) $ gunionValue root r
+    {-# INLINE gunionValue #-}
     gunionType root _ = gunionType root (Proxy @a) <> gunionType root (Proxy @b)
 
 instance {-# OVERLAPPABLE #-} (KnownSymbol conName) => GDuckUnion (C1 ('MetaCons conName foo bar) U1) where
     gunionValue (_ :: Proxy root) (M1 _) = (0, Allocated $ int8DuckValue 0)
+    {-# INLINE gunionValue #-}
     gunionType _root _ = [DuckStructField (Text.pack $ symbolVal (Proxy @conName)) "TINYINT" (appenderLogicalType (Proxy @Int8))]
 
 instance {-# OVERLAPPABLE #-} (KnownSymbol conName, Typeable a, AppenderDuckValue a) => GDuckUnion (C1 ('MetaCons conName foo bar) (S1 ms (Rec0 a))) where
     gunionValue (_ :: Proxy root) (M1 (M1 (K1 v))) = (0,  appenderDuckValue v)
+    {-# INLINE gunionValue #-}
     gunionType _root _ = [DuckStructField (Text.pack $ symbolVal (Proxy @conName)) (appenderTypeName (Proxy @a)) (appenderLogicalType (Proxy @a))]
 
-instance {-# OVERLAPS #-} (GDuckStruct a, KnownSymbol conName) => GDuckUnion (C1 ('MetaCons conName foo bar) a) where
+instance {-# OVERLAPS #-} (GDuckStructType a, GDuckStruct a, KnownSymbol conName) => GDuckUnion (C1 ('MetaCons conName foo bar) a) where
     gunionValue (_ :: Proxy root) (M1 v) = (0,) $ Allocated $ do
         structType <- cacheAppenderLogicalType (typeRep $ Proxy @(Tople root conName)) (duckStructLogicalType $ gstructType $ Proxy @a)
         withManyAllocated (gstructValue v) $ \childValues ->
-            withArray childValues $ c_duckdb_create_struct_value structType
+            withArray (V.toList childValues) $ c_duckdb_create_struct_value structType
+    {-# INLINE gunionValue #-}
     gunionType (_ :: Proxy root) _ = [DuckStructField (Text.pack $ symbolVal (Proxy @conName)) (gstructTypeName "STRUCT" t) (cacheAppenderLogicalType (typeRep $ Proxy @(Tople root conName)) $ duckStructLogicalType t)]
       where
         t = gstructType $ Proxy @a
 
 instance (GDuckUnion a) => GDuckUnion (M1 D c a) where
     gunionValue root (M1 v) = gunionValue root v
+    {-# INLINE gunionValue #-}
     gunionType root _ = gunionType root (Proxy @a)
 
 class GConstructorCount (f :: Type -> Type) where
@@ -469,9 +523,10 @@ class GConstructorCount (f :: Type -> Type) where
 
 instance (GConstructorCount a, GConstructorCount b) => GConstructorCount (a :+: b) where
   gconstructorCount _ = gconstructorCount (Proxy @a) + gconstructorCount (Proxy @b)
-
+  {-# INLINE gconstructorCount #-}
 instance GConstructorCount (C1 c f) where
   gconstructorCount _ = 1
+  {-# INLINE gconstructorCount #-}
 
 newtype ViaDuckEnum a = ViaDuckEnum a
 

--- a/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -17,6 +16,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Database.DuckDB.Simple.Appender.Generic (
     AppenderDuckValue (..),
@@ -35,7 +35,9 @@ module Database.DuckDB.Simple.Appender.Generic (
     duckStructValue,
     Allocated(..),
     DuckDBValue,
-    Uncached (..)
+    Uncached (..),
+    assertSuccess,
+    GDuckUnion(..)
 ) where
 
 import Control.Monad (join, (>=>))
@@ -59,7 +61,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Foreign as Text
 import qualified Data.Text.Foreign as TextForeign
-import qualified Data.Text.Lazy as T
+import qualified Data.Text.Lazy as LText
 import Data.Time (LocalTime (..), UTCTime, utc, utcToLocalTime, NominalDiffTime, nominalDiffTimeToSeconds)
 import Data.Time.Calendar (Day)
 import Data.Time.LocalTime (TimeOfDay)
@@ -70,7 +72,7 @@ import Foreign (Ptr, Storable (poke), alloca, castPtr, withMany)
 import Foreign.C.Types (CDouble (..), CFloat (CFloat))
 import Foreign.Marshal.Array (withArray)
 import GHC.Generics
-import GHC.IO (unsafePerformIO)
+import GHC.IO (unsafePerformIO, throwIO)
 import GHC.IORef (atomicModifyIORef'_)
 import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 import Database.DuckDB.FFI
@@ -78,6 +80,10 @@ import Database.DuckDB.Simple.FromField (BigNum (..), IntervalValue (..), TimeWi
 import Database.DuckDB.Simple.Internal
 import Database.DuckDB.Simple.Internal.ValueHelpers
 import Data.Scientific (Scientific)
+import GHC.Stack (HasCallStack)
+import Foreign.C (peekCString)
+import Data.Bifunctor (first)
+import Debug.Trace (traceShowWith)
 
 newtype Allocated a = Allocated {allocate :: IO a}
 
@@ -298,7 +304,6 @@ instance (AppenderDuckValue a) => AppenderDuckValue (Maybe a) where
     appendDuckValue app = maybe (c_duckdb_append_null app) (appendDuckValue app)
     appenderTypeName _ = appenderTypeName (Proxy @a)
 
--- | List values encode as DuckDB LIST (variable-length).
 instance (AppenderDuckValue a, Typeable a) => AppenderDuckValue [a] where
     appenderDuckValue = arrayDuckValue
     appenderLogicalTypeUncached _ = Uncached $ appenderLogicalType (Proxy @a) >>= c_duckdb_create_list_type
@@ -335,9 +340,9 @@ instance (AppenderDuckValue a, Ord a, Typeable a) => AppenderDuckValue (Set a) w
     appenderTypeName _ = appenderTypeName (Proxy @a) <> "[]"
 
 instance AppenderDuckValue Aeson.Value where
-    appenderDuckValue = Allocated . textDuckValue . T.toStrict . Aeson.encodeToLazyText
+    appenderDuckValue = Allocated . textDuckValue . LText.toStrict . Aeson.encodeToLazyText
     appenderLogicalTypeUncached _ = primitiveType DuckDBTypeVarchar
-    appendDuckValue app = appendDuckValue app . T.toStrict . Aeson.encodeToLazyText
+    appendDuckValue app = appendDuckValue app . LText.toStrict . Aeson.encodeToLazyText
     appenderTypeName _ = "JSON"
 
 instance (Ord k, AppenderDuckValue k, AppenderDuckValue v, Typeable k, Typeable v) => AppenderDuckValue (Map.Map k v) where
@@ -381,12 +386,12 @@ duckStructLogicalType flds = Uncached $ do
                 c_duckdb_create_struct_type typeArray nameArray (fromIntegral $ length flds)
 
 gunionTypeLogical :: [DuckStructField] -> Uncached DuckDBLogicalType
-gunionTypeLogical flds = Uncached $ do
-    evaluatedTypes <- mapM structLogicalType flds
-    withMany Text.withCString (structFieldName <$> flds) $ \namePtrs ->
+gunionTypeLogical ctors = Uncached $ do
+    evaluatedTypes <- mapM structLogicalType ctors
+    withMany Text.withCString (structFieldName <$> ctors) $ \namePtrs ->
         withArray namePtrs $ \nameArray ->
             withArray evaluatedTypes $ \typeArray ->
-                c_duckdb_create_union_type typeArray nameArray (fromIntegral $ length flds)
+                c_duckdb_create_union_type typeArray nameArray (fromIntegral $ length ctors)
 
 duckStructTypeName :: [DuckStructField] -> DuckTypeName
 duckStructTypeName = gstructTypeName "STRUCT"
@@ -418,42 +423,36 @@ instance (GDuckStruct a) => GDuckStruct (M1 D c a) where
 
 newtype ViaDuckUnion a = ViaDuckUnion a
 
-
-data SimpleUnion = Foo Int | Bar Text | Baz UTCTime
-  deriving stock (Generic)
-  deriving AppenderDuckValue via (ViaDuckUnion SimpleUnion)
-
-
 instance (Typeable a, GDuckUnion (Rep a), Generic a) => AppenderDuckValue (ViaDuckUnion a) where
     appenderDuckValue (ViaDuckUnion v) = Allocated $ do
         unionType <- cacheAppenderLogicalType (typeRep $ Proxy @a) (gunionTypeLogical $ gunionType (Proxy @a) (Proxy @(Rep a)))
-        let (ix, valueIO) = gunionValue (Proxy @a) 0 $ from v
-        withAllocated valueIO $ c_duckdb_create_union_value unionType (fromIntegral ix)
+        let (ix, valueIO) = traceShowWith fst $ gunionValue (Proxy @a) $ from v
+        withAllocated valueIO $ c_duckdb_create_union_value unionType ix
     appenderLogicalTypeUncached _ = gunionTypeLogical $ gunionType (Proxy @a) $ Proxy @(Rep a)
 
     appenderTypeName _ = gstructTypeName "UNION" $ gunionType (Proxy @a) $ Proxy @(Rep a)
 
 class GDuckUnion (f :: Type -> Type) where
-    gunionValue :: (Typeable root) => Proxy root -> Word -> f b -> (Word, Allocated DuckDBValue)
+    gunionValue :: (Typeable root) => Proxy root -> f b -> (Word64, Allocated DuckDBValue)
     gunionType :: (Typeable root) => Proxy root -> Proxy f -> [DuckStructField]
 
 data Tople (a :: Type) (b :: Symbol)
 
-instance (GDuckUnion a, GDuckUnion b) => GDuckUnion (a :+: b) where
-    gunionValue root ix (L1 l) = gunionValue root ix l
-    gunionValue root ix (R1 r) = gunionValue root (succ ix) r
+instance (GDuckUnion a, GDuckUnion b, GConstructorCount a) => GDuckUnion (a :+: b) where
+    gunionValue root (L1 l) = gunionValue root l
+    gunionValue root (R1 r) = first (+ gconstructorCount  (Proxy @a)) $ gunionValue root r
     gunionType root _ = gunionType root (Proxy @a) <> gunionType root (Proxy @b)
 
 instance {-# OVERLAPPABLE #-} (KnownSymbol conName) => GDuckUnion (C1 ('MetaCons conName foo bar) U1) where
-    gunionValue (_ :: Proxy root) ix (M1 _) = (ix, Allocated nullDuckValue)
+    gunionValue (_ :: Proxy root) (M1 _) = (0, Allocated $ int8DuckValue 0)
     gunionType _root _ = [DuckStructField (Text.pack $ symbolVal (Proxy @conName)) "TINYINT" (appenderLogicalType (Proxy @Int8))]
 
 instance {-# OVERLAPPABLE #-} (KnownSymbol conName, Typeable a, AppenderDuckValue a) => GDuckUnion (C1 ('MetaCons conName foo bar) (S1 ms (Rec0 a))) where
-    gunionValue (_ :: Proxy root) ix (M1 _) = (ix, Allocated nullDuckValue)
+    gunionValue (_ :: Proxy root) (M1 (M1 (K1 v))) = (0,  appenderDuckValue v)
     gunionType _root _ = [DuckStructField (Text.pack $ symbolVal (Proxy @conName)) (appenderTypeName (Proxy @a)) (appenderLogicalType (Proxy @a))]
 
 instance {-# OVERLAPS #-} (GDuckStruct a, KnownSymbol conName) => GDuckUnion (C1 ('MetaCons conName foo bar) a) where
-    gunionValue (_ :: Proxy root) ix (M1 v) = (ix,) $ Allocated $ do
+    gunionValue (_ :: Proxy root) (M1 v) = (0,) $ Allocated $ do
         structType <- cacheAppenderLogicalType (typeRep $ Proxy @(Tople root conName)) (duckStructLogicalType $ gstructType $ Proxy @a)
         withManyAllocated (gstructValue v) $ \childValues ->
             withArray childValues $ c_duckdb_create_struct_value structType
@@ -462,8 +461,17 @@ instance {-# OVERLAPS #-} (GDuckStruct a, KnownSymbol conName) => GDuckUnion (C1
         t = gstructType $ Proxy @a
 
 instance (GDuckUnion a) => GDuckUnion (M1 D c a) where
-    gunionValue root ix (M1 v) = gunionValue root ix v
+    gunionValue root (M1 v) = gunionValue root v
     gunionType root _ = gunionType root (Proxy @a)
+
+class GConstructorCount (f :: Type -> Type) where
+  gconstructorCount :: Proxy f -> Word64
+
+instance (GConstructorCount a, GConstructorCount b) => GConstructorCount (a :+: b) where
+  gconstructorCount _ = gconstructorCount (Proxy @a) + gconstructorCount (Proxy @b)
+
+instance GConstructorCount (C1 c f) where
+  gconstructorCount _ = 1
 
 newtype ViaDuckEnum a = ViaDuckEnum a
 
@@ -518,8 +526,8 @@ instance (Show a) => AppenderDuckValue (ViaShow a) where
 ---
 
 class AppendTableRow (a :: Type) where
-    appendDuckRow :: DuckDBAppender -> a -> IO DuckDBState
-    default appendDuckRow :: (Generic a, GAppendTableRow (Rep a)) => DuckDBAppender -> a -> IO DuckDBState
+    appendDuckRow :: DuckDBAppender -> a -> IO ()
+    default appendDuckRow :: (Generic a, GAppendTableRow (Rep a)) => DuckDBAppender -> a -> IO ()
     appendDuckRow app = gappendDuckRow app . from
 
     appendDuckRowSchema :: Proxy a -> [(Text, DuckTypeName)]
@@ -527,12 +535,12 @@ class AppendTableRow (a :: Type) where
     appendDuckRowSchema _ = gappendDuckRowSchema (Proxy @(Rep a))
 
 class GAppendTableRow (f :: Type -> Type) where
-    gappendDuckRow :: DuckDBAppender -> f b -> IO DuckDBState
+    gappendDuckRow :: DuckDBAppender -> f b -> IO ()
     gappendDuckRowSchema :: Proxy f -> [(Text, DuckTypeName)]
 
 instance (AppenderDuckValue a, KnownSymbol selectorName) => GAppendTableRow (S1 ('MetaSel ('Just selectorName) q w e) (K1 i a)) where
     gappendDuckRowSchema _ = [(Text.pack $ symbolVal (Proxy @selectorName), appenderTypeName (Proxy @a))]
-    gappendDuckRow app (M1 (K1 v)) = appendDuckValue app v
+    gappendDuckRow app (M1 (K1 v)) = assertSuccess app $ appendDuckValue app v
 
 instance (GAppendTableRow a, GAppendTableRow b) => GAppendTableRow (a :*: b) where
     gappendDuckRowSchema _ = gappendDuckRowSchema (Proxy @a) <> gappendDuckRowSchema (Proxy @b)
@@ -545,3 +553,11 @@ instance (GAppendTableRow a) => GAppendTableRow (M1 C c a) where
 instance (GAppendTableRow a) => GAppendTableRow (M1 D c a) where
     gappendDuckRowSchema _ = gappendDuckRowSchema (Proxy @a)
     gappendDuckRow app (M1 v) = gappendDuckRow app v
+
+assertSuccess :: (HasCallStack) => DuckDBAppender -> IO DuckDBState -> IO ()
+assertSuccess app f = f >>= \case
+  DuckDBSuccess -> pure ()
+  _errorStatus -> do
+        err <- c_duckdb_appender_error_data app >>= c_duckdb_error_data_message >>= peekCString
+        throwIO $ SQLError ("duckdb-simple: appender error" <> Text.pack err) Nothing Nothing -- FIXME: proper error handling
+{-# INLINE assertSuccess #-}

--- a/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
@@ -1,0 +1,519 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Database.DuckDB.Simple.Appender.Generic (
+    AppenderDuckValue (..),
+    ViaJSON (..),
+    ViaShow (..),
+    ViaDuckStruct (..),
+    ViaDuckUnion (..),
+    ViaDuckEnum (..),
+    AppendTableRow (..),
+    DuckTypeName (..),
+) where
+
+import Control.Monad (join, (>=>))
+import qualified Data.Aeson as A
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Text as Aeson
+import qualified Data.ByteString as BS
+import Data.Foldable (toList)
+import Data.HashMap.Strict (HashMap)
+import qualified Data.HashMap.Strict as HashMap
+import Data.IORef (IORef, newIORef, readIORef)
+import Data.Int (Int16, Int32, Int64, Int8)
+import Data.Kind (Type)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Data.Proxy (Proxy (..))
+import Data.Set (Set)
+import Data.String (IsString (..))
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Foreign as Text
+import qualified Data.Text.Foreign as TextForeign
+import qualified Data.Text.Lazy as T
+import Data.Time (LocalTime (..), UTCTime, utc, utcToLocalTime)
+import Data.Time.Calendar (Day)
+import Data.Time.LocalTime (TimeOfDay)
+import Data.Typeable (TypeRep, Typeable, typeRep)
+import qualified Data.UUID as UUID
+import Data.Word (Word16, Word32, Word64, Word8)
+import Foreign (Ptr, Storable (poke), alloca, castPtr, withMany)
+import Foreign.C.Types (CDouble (..), CFloat (CFloat))
+import Foreign.Marshal.Array (withArray)
+import GHC.Generics
+import GHC.IO (unsafePerformIO)
+import GHC.IORef (atomicModifyIORef'_)
+import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
+import Database.DuckDB.FFI
+import Database.DuckDB.Simple.FromField (BigNum (..), IntervalValue (..), TimeWithZone (..))
+import Database.DuckDB.Simple.Internal
+import Database.DuckDB.Simple.Internal.ValueHelpers
+
+newtype Allocated a = Allocated {allocate :: IO a}
+
+newtype DuckTypeName = DuckTypeName {renderDuckTypeName :: Text}
+    deriving newtype (Semigroup, Monoid, IsString)
+
+class Destroy a where
+    destroyAllocated :: a -> IO ()
+
+instance Destroy DuckDBValue where
+    destroyAllocated = destroyValue
+
+instance Destroy DuckDBLogicalType where
+    destroyAllocated = destroyLogicalType
+
+withAllocated :: (Destroy a) => Allocated a -> (a -> IO b) -> IO b
+withAllocated alloc go = do
+    val <- allocate alloc
+    go val <* destroyAllocated val
+{-# SPECIALIZE INLINE withAllocated :: Allocated DuckDBValue -> (DuckDBValue -> IO DuckDBState) -> IO DuckDBState #-}
+
+withManyAllocated :: (Destroy a, Foldable f, Traversable f) => f (Allocated a) -> (f a -> IO b) -> IO b
+withManyAllocated alloc go = do
+    a <- mapM allocate alloc
+    go a <* mapM_ destroyAllocated a
+{-# SPECIALIZE INLINE withManyAllocated :: [Allocated DuckDBValue] -> ([DuckDBValue] -> IO [DuckDBState]) -> IO [DuckDBState] #-}
+
+cache :: IORef (HashMap TypeRep DuckDBLogicalType)
+cache = unsafePerformIO (newIORef mempty)
+{-# NOINLINE cache #-}
+
+{- | We only materialize duckdb logical types once and we never release them.
+This resulted in a significant performance gain when using high-performance appender API.
+-}
+appenderLogicalType :: (AppenderDuckValue a, Typeable a) => Proxy a -> IO DuckDBLogicalType
+appenderLogicalType pxy = cacheAppenderLogicalType (typeRep pxy) (appenderLogicalTypeUncached pxy)
+
+newtype Uncached a = Uncached (IO a)
+
+cacheAppenderLogicalType :: TypeRep -> Uncached DuckDBLogicalType -> IO DuckDBLogicalType
+cacheAppenderLogicalType hsRep (Uncached alloc) = do
+    cachedMb <- HashMap.lookup hsRep <$> readIORef cache
+    case cachedMb of
+        Just cached -> pure cached
+        Nothing -> do
+            rep <- alloc
+            _ <- atomicModifyIORef'_ cache (HashMap.insert hsRep rep)
+            pure rep
+
+class AppenderDuckValue a where
+    appenderDuckValue :: a -> Allocated DuckDBValue
+
+    appendDuckValue :: DuckDBAppender -> a -> IO DuckDBState
+    appendDuckValue appender val = withAllocated (appenderDuckValue val) (c_duckdb_append_value appender)
+
+    appenderLogicalTypeUncached :: Proxy a -> Uncached DuckDBLogicalType
+    appenderTypeName :: Proxy a -> DuckTypeName
+
+primitiveType :: DuckDBType -> Uncached DuckDBLogicalType
+primitiveType = Uncached . c_duckdb_create_logical_type
+
+instance AppenderDuckValue Bool where
+    appenderDuckValue = Allocated . boolDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeBoolean
+    appendDuckValue app value = c_duckdb_append_bool app (if value then 1 else 0)
+    appenderTypeName _ = "BOOL"
+
+instance AppenderDuckValue Int where
+    appenderDuckValue = Allocated . int64DuckValue . fromIntegral
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeBigInt
+    appendDuckValue app = c_duckdb_append_int64 app . fromIntegral
+    appenderTypeName _ = "BIGINT"
+
+instance AppenderDuckValue Int8 where
+    appenderDuckValue = Allocated . int8DuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeTinyInt
+    appendDuckValue = c_duckdb_append_int8
+    appenderTypeName _ = "TINYINT"
+
+instance AppenderDuckValue Int16 where
+    appenderDuckValue = Allocated . int16DuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeSmallInt
+    appendDuckValue = c_duckdb_append_int16
+    appenderTypeName _ = "SMALLINT"
+
+instance AppenderDuckValue Int32 where
+    appenderDuckValue = Allocated . int32DuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeInteger
+    appendDuckValue = c_duckdb_append_int32
+    appenderTypeName _ = "INT"
+
+instance AppenderDuckValue Int64 where
+    appenderDuckValue = Allocated . int64DuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeBigInt
+    appendDuckValue = c_duckdb_append_int64
+    appenderTypeName _ = "BIGINT"
+
+instance AppenderDuckValue Integer where
+    appenderDuckValue = Allocated . bigNumDuckValue . BigNum
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeBigNum
+    appenderTypeName _ = "BIGNUM"
+
+instance AppenderDuckValue Word where
+    appenderDuckValue = Allocated . uint64DuckValue . fromIntegral
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeUBigInt
+    appendDuckValue app = c_duckdb_append_uint64 app . fromIntegral
+    appenderTypeName _ = "UBIGINT"
+
+instance AppenderDuckValue Word8 where
+    appenderDuckValue = Allocated . uint8DuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeUTinyInt
+    appendDuckValue = c_duckdb_append_uint8
+    appenderTypeName _ = "UTINYINT"
+
+instance AppenderDuckValue Word16 where
+    appenderDuckValue = Allocated . uint16DuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeUSmallInt
+    appendDuckValue = c_duckdb_append_uint16
+    appenderTypeName _ = "USMALLINT"
+
+instance AppenderDuckValue Word32 where
+    appenderDuckValue = Allocated . uint32DuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeUInteger
+    appendDuckValue = c_duckdb_append_uint32
+    appenderTypeName _ = "UINTEGER"
+
+instance AppenderDuckValue Word64 where
+    appenderDuckValue = Allocated . uint64DuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeUBigInt
+    appendDuckValue = c_duckdb_append_uint64
+    appenderTypeName _ = "UBIGINT"
+
+instance AppenderDuckValue Float where
+    appenderDuckValue = Allocated . floatDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeFloat
+    appendDuckValue app = c_duckdb_append_float app . CFloat
+    appenderTypeName _ = "FLOAT"
+
+instance AppenderDuckValue Double where
+    appenderDuckValue = Allocated . doubleDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeDouble
+    appendDuckValue app = c_duckdb_append_double app . CDouble
+    appenderTypeName _ = "DOUBLE"
+
+instance AppenderDuckValue Text where
+    appenderDuckValue = Allocated . textDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeVarchar
+    appendDuckValue app txt = TextForeign.withCString txt (c_duckdb_append_varchar app)
+    appenderTypeName _ = "VARCHAR"
+
+instance AppenderDuckValue BS.ByteString where
+    appenderDuckValue = Allocated . blobDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeBlob
+    appendDuckValue app bs = BS.useAsCStringLen bs \(ptr, len) ->
+        c_duckdb_append_blob app (castPtr ptr :: Ptr ()) (fromIntegral len)
+    appenderTypeName _ = "BLOB"
+
+instance AppenderDuckValue Day where
+    appenderDuckValue = Allocated . dayDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeDate
+    appendDuckValue app = encodeDay >=> c_duckdb_append_date app
+    appenderTypeName _ = "DATE"
+
+instance AppenderDuckValue TimeOfDay where
+    appenderDuckValue = Allocated . timeOfDayDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeTime
+    appendDuckValue app = encodeTimeOfDay >=> c_duckdb_append_time app
+    appenderTypeName _ = "TIME"
+
+instance AppenderDuckValue LocalTime where
+    appenderDuckValue = Allocated . localTimeDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeTimestamp
+    appendDuckValue app = encodeLocalTime >=> c_duckdb_append_timestamp app
+    appenderTypeName _ = "TIMESTAMP"
+
+instance AppenderDuckValue UTCTime where
+    appenderDuckValue = Allocated . utcTimeDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeTimestampTz
+    appendDuckValue app = encodeLocalTime . utcToLocalTime utc >=> c_duckdb_append_timestamp app
+    appenderTypeName _ = "TIMESTAMPTZ"
+
+instance AppenderDuckValue UUID.UUID where
+    appenderDuckValue = Allocated . uuidDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeUUID
+    appenderTypeName _ = "UUID"
+
+instance AppenderDuckValue IntervalValue where -- TODO: Make it nominal diff time!
+    appenderDuckValue = Allocated . intervalDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeInterval
+    appendDuckValue app IntervalValue{intervalMonths, intervalDays, intervalMicros} =
+        alloca \ptr -> do
+            poke ptr (DuckDBInterval intervalMonths intervalDays intervalMicros)
+            c_duckdb_append_interval app ptr
+    appenderTypeName _ = "INTERVAL"
+
+instance AppenderDuckValue TimeWithZone where
+    appenderDuckValue = Allocated . timeWithZoneDuckValue
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeTimeTz
+    appenderTypeName _ = "TIMETZ"
+
+instance (AppenderDuckValue a) => AppenderDuckValue (Maybe a) where
+    appenderDuckValue (Just x) = appenderDuckValue x
+    appenderDuckValue Nothing = Allocated nullDuckValue
+    appenderLogicalTypeUncached _ = appenderLogicalTypeUncached (Proxy :: Proxy a)
+    appendDuckValue app = maybe (c_duckdb_append_null app) (appendDuckValue app)
+    appenderTypeName _ = appenderTypeName (Proxy @a)
+
+-- | List values encode as DuckDB LIST (variable-length).
+instance (AppenderDuckValue a, Typeable a) => AppenderDuckValue [a] where
+    appenderDuckValue = arrayDuckValue
+    appenderLogicalTypeUncached _ = Uncached $ appenderLogicalType (Proxy @a) >>= c_duckdb_create_list_type
+    appenderTypeName _ = appenderTypeName (Proxy @a) <> "[]"
+
+-- instance (AppenderDuckValue a) => AppenderDuckValue (Vector len a) where -- from vector-sized, I don't need it right now so whatever
+--     appenderDuckValue = arrayDuckValue
+--     appenderLogicalTypeUncached _ = do
+--       inner <- leakAllocated <$> appenderLogicalType (Proxy @a)
+--       Allocated <$> c_duckdb_create_array_type size inner
+
+arrayDuckValue ::
+    forall a f.
+    (AppenderDuckValue a, Foldable f, Typeable a) =>
+    f a ->
+    Allocated DuckDBValue
+arrayDuckValue arr = Allocated $ do
+    elementType <- appenderLogicalType (Proxy :: Proxy a)
+    let elemsList = toList arr
+        count = length elemsList
+    withManyAllocated (appenderDuckValue <$> elemsList) $ \values ->
+        withArray values \ptr ->
+            c_duckdb_create_array_value elementType ptr (fromIntegral count)
+
+-- | NonEmpty list values encode as DuckDB LIST (variable-length).
+instance (AppenderDuckValue a, Typeable a) => AppenderDuckValue (NonEmpty a) where
+    appenderDuckValue = appenderDuckValue . toList
+    appenderLogicalTypeUncached _ = Uncached $ appenderLogicalType (Proxy @[a])
+    appenderTypeName _ = appenderTypeName (Proxy @a) <> "[]"
+
+instance (AppenderDuckValue a, Ord a, Typeable a) => AppenderDuckValue (Set a) where
+    appenderDuckValue = appenderDuckValue . toList
+    appenderLogicalTypeUncached _ = Uncached $ appenderLogicalType (Proxy @[a])
+    appenderTypeName _ = appenderTypeName (Proxy @a) <> "[]"
+
+instance AppenderDuckValue Aeson.Value where
+    appenderDuckValue = Allocated . textDuckValue . T.toStrict . Aeson.encodeToLazyText
+    appenderLogicalTypeUncached _ = primitiveType DuckDBTypeVarchar
+    appendDuckValue app = appendDuckValue app . T.toStrict . Aeson.encodeToLazyText
+    appenderTypeName _ = "JSON"
+
+instance (Ord k, AppenderDuckValue k, AppenderDuckValue v, Typeable k, Typeable v) => AppenderDuckValue (Map.Map k v) where
+    appenderDuckValue m = Allocated $ do
+        mapType <- appenderLogicalType (Proxy @(Map k v))
+        let elemsList = Map.toList m
+            count = length elemsList
+        withManyAllocated (appenderDuckValue . fst <$> elemsList) $ \keys ->
+            withManyAllocated (appenderDuckValue . snd <$> elemsList) $ \values ->
+                withArray keys \ptrK ->
+                    withArray values \ptrV -> c_duckdb_create_map_value mapType ptrK ptrV (fromIntegral count)
+
+    appenderLogicalTypeUncached _ = Uncached $ join $ c_duckdb_create_map_type <$> appenderLogicalType (Proxy @k) <*> appenderLogicalType (Proxy @v)
+    appenderTypeName _ = "MAP(" <> appenderTypeName (Proxy @k) <> ", " <> appenderTypeName (Proxy @v) <> ")"
+
+---
+
+newtype ViaDuckStruct a = ViaDuckStruct a
+
+instance (Typeable a, GDuckStruct (Rep a), Generic a) => AppenderDuckValue (ViaDuckStruct a) where
+    appenderDuckValue (ViaDuckStruct v) = Allocated $ do
+        structType <- cacheAppenderLogicalType (typeRep $ Proxy @a) (gstructTypeIO $ gstructType $ Proxy @(Rep a))
+        withManyAllocated (gstructValue $ from v) $ \childValues ->
+            withArray childValues $ c_duckdb_create_struct_value structType
+
+    appenderLogicalTypeUncached _ = gstructTypeIO $ gstructType $ Proxy @(Rep a)
+
+    appenderTypeName _ = gstructTypeName "STRUCT" $ gstructType $ Proxy @(Rep a)
+
+data GDuckStructField = GDuckStructField {gname :: Text, _gtypeName :: DuckTypeName, glogicalType :: IO DuckDBLogicalType}
+
+gstructTypeIO :: [GDuckStructField] -> Uncached DuckDBLogicalType
+gstructTypeIO flds = Uncached $ do
+    evaluatedTypes <- mapM glogicalType flds
+    withMany Text.withCString (gname <$> flds) $ \namePtrs ->
+        withArray namePtrs $ \nameArray ->
+            withArray evaluatedTypes $ \typeArray ->
+                c_duckdb_create_struct_type typeArray nameArray (fromIntegral $ length flds)
+
+gunionTypeLogical :: [GDuckStructField] -> Uncached DuckDBLogicalType
+gunionTypeLogical flds = Uncached $ do
+    evaluatedTypes <- mapM glogicalType flds
+    withMany Text.withCString (gname <$> flds) $ \namePtrs ->
+        withArray namePtrs $ \nameArray ->
+            withArray evaluatedTypes $ \typeArray ->
+                c_duckdb_create_union_type typeArray nameArray (fromIntegral $ length flds)
+
+gstructTypeName :: Text -> [GDuckStructField] -> DuckTypeName
+gstructTypeName pfx flds = DuckTypeName $ pfx <> "(" <> Text.intercalate ", " ["\"" <> nme <> "\" " <> renderDuckTypeName tpeNme | GDuckStructField nme tpeNme _ <- flds] <> ")"
+
+class GDuckStruct (f :: Type -> Type) where
+    gstructValue :: f b -> [Allocated DuckDBValue]
+    gstructType :: Proxy f -> [GDuckStructField]
+
+instance (AppenderDuckValue a, KnownSymbol selectorName, Typeable a) => GDuckStruct (S1 ('MetaSel ('Just selectorName) q w e) (K1 i a)) where
+    gstructValue (M1 (K1 v)) = pure $ appenderDuckValue v
+    gstructType _ = pure $ GDuckStructField (Text.pack $ symbolVal (Proxy @selectorName)) (appenderTypeName (Proxy @a)) (appenderLogicalType (Proxy @a))
+
+instance (GDuckStruct a, GDuckStruct b) => GDuckStruct (a :*: b) where
+    gstructValue (a :*: b) = gstructValue a <> gstructValue b
+    gstructType _ = gstructType (Proxy @a) <> gstructType (Proxy @b)
+
+instance (GDuckStruct a) => GDuckStruct (M1 C c a) where
+    gstructValue (M1 v) = gstructValue v
+    gstructType _ = gstructType (Proxy @a)
+
+instance (GDuckStruct a) => GDuckStruct (M1 D c a) where
+    gstructValue (M1 v) = gstructValue v
+    gstructType _ = gstructType (Proxy @a)
+
+--
+
+newtype ViaDuckUnion a = ViaDuckUnion a
+
+
+data SimpleUnion = Foo Int | Bar Text | Baz UTCTime
+  deriving stock (Generic)
+  deriving AppenderDuckValue via (ViaDuckUnion SimpleUnion)
+
+
+instance (Typeable a, GDuckUnion (Rep a), Generic a) => AppenderDuckValue (ViaDuckUnion a) where
+    appenderDuckValue (ViaDuckUnion v) = Allocated $ do
+        unionType <- cacheAppenderLogicalType (typeRep $ Proxy @a) (gunionTypeLogical $ gunionType (Proxy @a) (Proxy @(Rep a)))
+        let (ix, valueIO) = gunionValue (Proxy @a) 0 $ from v
+        withAllocated valueIO $ c_duckdb_create_union_value unionType (fromIntegral ix)
+    appenderLogicalTypeUncached _ = gunionTypeLogical $ gunionType (Proxy @a) $ Proxy @(Rep a)
+
+    appenderTypeName _ = gstructTypeName "UNION" $ gunionType (Proxy @a) $ Proxy @(Rep a)
+
+class GDuckUnion (f :: Type -> Type) where
+    gunionValue :: (Typeable root) => Proxy root -> Word -> f b -> (Word, Allocated DuckDBValue)
+    gunionType :: (Typeable root) => Proxy root -> Proxy f -> [GDuckStructField]
+
+data Tople (a :: Type) (b :: Symbol)
+
+instance (GDuckUnion a, GDuckUnion b) => GDuckUnion (a :+: b) where
+    gunionValue root ix (L1 l) = gunionValue root ix l
+    gunionValue root ix (R1 r) = gunionValue root (succ ix) r
+    gunionType root _ = gunionType root (Proxy @a) <> gunionType root (Proxy @b)
+
+instance {-# OVERLAPPABLE #-} (KnownSymbol conName) => GDuckUnion (C1 ('MetaCons conName foo bar) U1) where
+    gunionValue (_ :: Proxy root) ix (M1 _) = (ix, Allocated nullDuckValue)
+    gunionType _root _ = [GDuckStructField (Text.pack $ symbolVal (Proxy @conName)) "TINYINT" (appenderLogicalType (Proxy @Int8))]
+
+instance {-# OVERLAPPABLE #-} (KnownSymbol conName, Typeable a, AppenderDuckValue a) => GDuckUnion (C1 ('MetaCons conName foo bar) (S1 ms (Rec0 a))) where
+    gunionValue (_ :: Proxy root) ix (M1 _) = (ix, Allocated nullDuckValue)
+    gunionType _root _ = [GDuckStructField (Text.pack $ symbolVal (Proxy @conName)) (appenderTypeName (Proxy @a)) (appenderLogicalType (Proxy @a))]
+
+instance {-# OVERLAPS #-} (GDuckStruct a, KnownSymbol conName) => GDuckUnion (C1 ('MetaCons conName foo bar) a) where
+    gunionValue (_ :: Proxy root) ix (M1 v) = (ix,) $ Allocated $ do
+        structType <- cacheAppenderLogicalType (typeRep $ Proxy @(Tople root conName)) (gstructTypeIO $ gstructType $ Proxy @a)
+        withManyAllocated (gstructValue v) $ \childValues ->
+            withArray childValues $ c_duckdb_create_struct_value structType
+    gunionType (_ :: Proxy root) _ = [GDuckStructField (Text.pack $ symbolVal (Proxy @conName)) (gstructTypeName "STRUCT" t) (cacheAppenderLogicalType (typeRep $ Proxy @(Tople root conName)) $ gstructTypeIO t)]
+      where
+        t = gstructType $ Proxy @a
+
+instance (GDuckUnion a) => GDuckUnion (M1 D c a) where
+    gunionValue root ix (M1 v) = gunionValue root ix v
+    gunionType root _ = gunionType root (Proxy @a)
+
+newtype ViaDuckEnum a = ViaDuckEnum a
+
+instance (GDuckEnum (Rep a), Generic a, Typeable a) => AppenderDuckValue (ViaDuckEnum a) where
+    appenderDuckValue (ViaDuckEnum v) = Allocated $ do
+        unionType <- cacheAppenderLogicalType (typeRep $ Proxy @a) (genumLogicalType $ genumType (Proxy @(Rep a)))
+        let ix = genumValue 0 $ from v
+        c_duckdb_create_enum_value unionType (fromIntegral ix)
+    appenderLogicalTypeUncached _ = genumLogicalType $ genumType (Proxy @(Rep a))
+    appenderTypeName _ = DuckTypeName $ "ENUM(" <> Text.intercalate ", " ["\'" <> ctor <> "\'" | ctor <- genumType $ Proxy @(Rep a)] <> ")"
+
+genumLogicalType :: [Text] -> Uncached DuckDBLogicalType
+genumLogicalType els = Uncached $ do
+    withMany Text.withCString els $ \namePtrs ->
+        withArray namePtrs \nameArray ->
+            c_duckdb_create_enum_type nameArray (fromIntegral $ length els)
+
+class GDuckEnum (f :: Type -> Type) where
+    genumValue :: Word64 -> f b -> Word64
+    genumType :: Proxy f -> [Text]
+
+instance (GDuckEnum a, GDuckEnum b) => GDuckEnum (a :+: b) where
+    genumValue ix (L1 l) = genumValue ix l
+    genumValue ix (R1 r) = genumValue (succ ix) r
+    genumType _ = genumType (Proxy @a) <> genumType (Proxy @b)
+
+instance (KnownSymbol conName) => GDuckEnum (C1 ('MetaCons conName foo bar) U1) where
+    genumValue ix (M1 _) = ix
+    genumType _ = [Text.pack $ symbolVal (Proxy @conName)]
+
+instance (GDuckEnum a) => GDuckEnum (M1 D c a) where
+    genumValue ix (M1 v) = genumValue ix v
+    genumType _ = genumType (Proxy @a)
+
+--
+
+newtype ViaJSON a = ViaJSON a
+
+instance (A.ToJSON a) => AppenderDuckValue (ViaJSON a) where
+    appenderDuckValue (ViaJSON v) = appenderDuckValue $ A.toJSON v
+    appenderLogicalTypeUncached _ = appenderLogicalTypeUncached (Proxy @A.Value)
+    appenderTypeName _ = appenderTypeName (Proxy @A.Value)
+
+--
+
+newtype ViaShow a = ViaShow a
+
+instance (Show a) => AppenderDuckValue (ViaShow a) where
+    appenderDuckValue (ViaShow v) = appenderDuckValue $ Text.pack $ show v
+    appenderLogicalTypeUncached _ = appenderLogicalTypeUncached (Proxy @Text)
+    appenderTypeName _ = appenderTypeName (Proxy @Text)
+
+---
+
+class AppendTableRow (a :: Type) where
+    appendDuckRow :: DuckDBAppender -> a -> IO DuckDBState
+    default appendDuckRow :: (Generic a, GAppendTableRow (Rep a)) => DuckDBAppender -> a -> IO DuckDBState
+    appendDuckRow app = gappendDuckRow app . from
+
+    appendDuckRowSchema :: Proxy a -> [(Text, DuckTypeName)]
+    default appendDuckRowSchema :: (Generic a, GAppendTableRow (Rep a)) => Proxy a -> [(Text, DuckTypeName)]
+    appendDuckRowSchema _ = gappendDuckRowSchema (Proxy @(Rep a))
+
+class GAppendTableRow (f :: Type -> Type) where
+    gappendDuckRow :: DuckDBAppender -> f b -> IO DuckDBState
+    gappendDuckRowSchema :: Proxy f -> [(Text, DuckTypeName)]
+
+instance (AppenderDuckValue a, KnownSymbol selectorName) => GAppendTableRow (S1 ('MetaSel ('Just selectorName) q w e) (K1 i a)) where
+    gappendDuckRowSchema _ = [(Text.pack $ symbolVal (Proxy @selectorName), appenderTypeName (Proxy @a))]
+    gappendDuckRow app (M1 (K1 v)) = appendDuckValue app v
+
+instance (GAppendTableRow a, GAppendTableRow b) => GAppendTableRow (a :*: b) where
+    gappendDuckRowSchema _ = gappendDuckRowSchema (Proxy @a) <> gappendDuckRowSchema (Proxy @b)
+    gappendDuckRow app (a :*: b) = gappendDuckRow app a >> gappendDuckRow app b
+
+instance (GAppendTableRow a) => GAppendTableRow (M1 C c a) where
+    gappendDuckRowSchema _ = gappendDuckRowSchema (Proxy @a)
+    gappendDuckRow app (M1 v) = gappendDuckRow app v
+
+instance (GAppendTableRow a) => GAppendTableRow (M1 D c a) where
+    gappendDuckRowSchema _ = gappendDuckRowSchema (Proxy @a)
+    gappendDuckRow app (M1 v) = gappendDuckRow app v

--- a/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
@@ -34,7 +34,8 @@ module Database.DuckDB.Simple.Appender.Generic (
     duckStructTypeName,
     duckStructValue,
     Allocated(..),
-    DuckDBValue
+    DuckDBValue,
+    Uncached (..)
 ) where
 
 import Control.Monad (join, (>=>))
@@ -59,7 +60,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Foreign as Text
 import qualified Data.Text.Foreign as TextForeign
 import qualified Data.Text.Lazy as T
-import Data.Time (LocalTime (..), UTCTime, utc, utcToLocalTime)
+import Data.Time (LocalTime (..), UTCTime, utc, utcToLocalTime, NominalDiffTime, nominalDiffTimeToSeconds)
 import Data.Time.Calendar (Day)
 import Data.Time.LocalTime (TimeOfDay)
 import Data.Typeable (TypeRep, Typeable, typeRep)
@@ -76,6 +77,7 @@ import Database.DuckDB.FFI
 import Database.DuckDB.Simple.FromField (BigNum (..), IntervalValue (..), TimeWithZone (..))
 import Database.DuckDB.Simple.Internal
 import Database.DuckDB.Simple.Internal.ValueHelpers
+import Debug.Trace (trace, traceIO)
 
 newtype Allocated a = Allocated {allocate :: IO a}
 
@@ -262,7 +264,14 @@ instance AppenderDuckValue UUID.UUID where
     appenderLogicalTypeUncached _ = primitiveType DuckDBTypeUUID
     appenderTypeName _ = "UUID"
 
-instance AppenderDuckValue IntervalValue where -- TODO: Make it nominal diff time!
+instance AppenderDuckValue NominalDiffTime where
+  appenderDuckValue v = appenderDuckValue $ IntervalValue{intervalMonths = 0, intervalDays = 0, intervalMicros = truncate $ nominalDiffTimeToSeconds v * 1e6}
+  appendDuckValue app v = appendDuckValue app $ IntervalValue{intervalMonths = 0, intervalDays = 0, intervalMicros = truncate $ nominalDiffTimeToSeconds v * 1e6}
+  appenderLogicalTypeUncached _ = appenderLogicalTypeUncached (Proxy @IntervalValue)
+  appenderTypeName _ = appenderTypeName (Proxy @IntervalValue)
+
+
+instance AppenderDuckValue IntervalValue where
     appenderDuckValue = Allocated . intervalDuckValue
     appenderLogicalTypeUncached _ = primitiveType DuckDBTypeInterval
     appendDuckValue app IntervalValue{intervalMonths, intervalDays, intervalMicros} =
@@ -452,11 +461,10 @@ instance (GDuckUnion a) => GDuckUnion (M1 D c a) where
 
 newtype ViaDuckEnum a = ViaDuckEnum a
 
-instance (GDuckEnum (Rep a), Generic a, Typeable a) => AppenderDuckValue (ViaDuckEnum a) where
+instance (GDuckEnum (Rep a), Generic a, Typeable a, Show a, Enum a) => AppenderDuckValue (ViaDuckEnum a) where
     appenderDuckValue (ViaDuckEnum v) = Allocated $ do
         unionType <- cacheAppenderLogicalType (typeRep $ Proxy @a) (genumLogicalType $ genumType (Proxy @(Rep a)))
-        let ix = genumValue 0 $ from v
-        c_duckdb_create_enum_value unionType (fromIntegral ix)
+        c_duckdb_create_enum_value unionType (fromIntegral $ fromEnum v)
     appenderLogicalTypeUncached _ = genumLogicalType $ genumType (Proxy @(Rep a))
     appenderTypeName _ = DuckTypeName $ "ENUM(" <> Text.intercalate ", " ["\'" <> ctor <> "\'" | ctor <- genumType $ Proxy @(Rep a)] <> ")"
 

--- a/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
@@ -614,5 +614,5 @@ assertSuccess app f = f >>= \case
   DuckDBSuccess -> pure ()
   _errorStatus -> do
         err <- c_duckdb_appender_error_data app >>= c_duckdb_error_data_message >>= peekCString
-        throwIO $ SQLError ("duckdb-simple: appender error" <> Text.pack err) Nothing Nothing -- FIXME: proper error handling
+        throwIO $ appenderError $ Text.pack err
 {-# INLINE assertSuccess #-}

--- a/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Appender/Generic.hs
@@ -253,7 +253,7 @@ instance AppenderDuckValue BS.ByteString where
 instance AppenderDuckValue Day where
     appenderDuckValue = Allocated . dayDuckValue
     appenderLogicalTypeUncached _ = primitiveType DuckDBTypeDate
-    appendDuckValue app = encodeDay >=> c_duckdb_append_date app
+    appendDuckValue app = encodeDay >=> maybe (c_duckdb_append_null app) (c_duckdb_append_date app)
     appenderTypeName _ = "DATE"
 
 instance AppenderDuckValue TimeOfDay where
@@ -265,13 +265,13 @@ instance AppenderDuckValue TimeOfDay where
 instance AppenderDuckValue LocalTime where
     appenderDuckValue = Allocated . localTimeDuckValue
     appenderLogicalTypeUncached _ = primitiveType DuckDBTypeTimestamp
-    appendDuckValue app = encodeLocalTime >=> c_duckdb_append_timestamp app
+    appendDuckValue app = encodeLocalTime >=> maybe (c_duckdb_append_null app) (c_duckdb_append_timestamp app)
     appenderTypeName _ = "TIMESTAMP"
 
 instance AppenderDuckValue UTCTime where
     appenderDuckValue = Allocated . utcTimeDuckValue
     appenderLogicalTypeUncached _ = primitiveType DuckDBTypeTimestampTz
-    appendDuckValue app = encodeLocalTime . utcToLocalTime utc >=> c_duckdb_append_timestamp app
+    appendDuckValue app = encodeLocalTime . utcToLocalTime utc >=> maybe (c_duckdb_append_null app) (c_duckdb_append_timestamp app)
     appenderTypeName _ = "TIMESTAMPTZ"
 
 instance AppenderDuckValue UUID.UUID where

--- a/duckdb-simple/src/Database/DuckDB/Simple/FileSystem.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/FileSystem.hs
@@ -25,6 +25,7 @@ import Foreign.C.String (peekCString, withCString)
 import Foreign.Marshal.Alloc (alloca, free, mallocBytes)
 import Foreign.Ptr (castPtr, nullPtr)
 import Foreign.Storable (peek, poke)
+import GHC.Stack (HasCallStack, callStack)
 
 -- | Open a file through DuckDB's file-system layer for the duration of an action.
 withFileHandle :: Connection -> FilePath -> [DuckDBFileFlag] -> (DuckDBFileHandle -> IO a) -> IO a
@@ -125,7 +126,7 @@ throwFileHandleError handle fallback = do
     err <- c_duckdb_file_handle_error_data handle
     throwErrorData err fallback
 
-throwErrorData :: DuckDBErrorData -> Text -> IO a
+throwErrorData :: HasCallStack => DuckDBErrorData -> Text -> IO a
 throwErrorData err fallback =
     bracket (pure err) destroyErrorData \errData -> do
         msgPtr <- c_duckdb_error_data_message errData
@@ -139,13 +140,14 @@ throwErrorData err fallback =
                 { sqlErrorMessage = message
                 , sqlErrorType = Just errType
                 , sqlErrorQuery = Nothing
+                , sqlErrorCallStack = callStack
                 }
 
 destroyErrorData :: DuckDBErrorData -> IO ()
 destroyErrorData err =
     alloca \ptr -> poke ptr err >> c_duckdb_destroy_error_data ptr
 
-expectState :: String -> IO DuckDBState -> IO ()
+expectState :: HasCallStack => String -> IO DuckDBState -> IO ()
 expectState label action = do
     rc <- action
     if rc == DuckDBSuccess
@@ -156,4 +158,5 @@ expectState label action = do
                     { sqlErrorMessage = Text.pack ("duckdb-simple: " <> label <> " failed")
                     , sqlErrorType = Nothing
                     , sqlErrorQuery = Nothing
+                , sqlErrorCallStack = callStack
                     }

--- a/duckdb-simple/src/Database/DuckDB/Simple/FromRow.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/FromRow.hs
@@ -44,6 +44,7 @@ import Database.DuckDB.Simple.FromField
 import Database.DuckDB.Simple.Internal (SQLError (..))
 import Database.DuckDB.Simple.Ok (Ok (..))
 import Database.DuckDB.Simple.Types (Only (..), Query, (:.) (..))
+import GHC.Stack (HasCallStack, callStack)
 
 -- | Row parsing environment (read-only data available to the parser).
 newtype RowParseRO = RowParseRO
@@ -218,16 +219,17 @@ instance (FromField a) => FromRow [a] where
         replicateM remaining field
 
 -- | Convert a @ResultError@ into a user-facing @SQLError@.
-resultErrorToSqlError :: Query -> ResultError -> SQLError
+resultErrorToSqlError :: HasCallStack => Query -> ResultError -> SQLError
 resultErrorToSqlError query err =
     SQLError
         { sqlErrorMessage = renderError err
         , sqlErrorType = Nothing
         , sqlErrorQuery = Just query
+        , sqlErrorCallStack = callStack
         }
 
 -- | Collapse parser failure diagnostics into an @SQLError@ while preserving the query.
-rowErrorsToSqlError :: Query -> [SomeException] -> SQLError
+rowErrorsToSqlError :: HasCallStack => Query -> [SomeException] -> SQLError
 rowErrorsToSqlError query errs =
     case listToMaybe (mapMaybe (fromException :: SomeException -> Maybe ResultError) errs) of
         Just resultErr -> resultErrorToSqlError query resultErr
@@ -243,6 +245,7 @@ rowErrorsToSqlError query errs =
                                 ]
                         , sqlErrorType = Nothing
                         , sqlErrorQuery = Just query
+                        , sqlErrorCallStack = callStack
                         }
                 Nothing ->
                     SQLError
@@ -250,6 +253,7 @@ rowErrorsToSqlError query errs =
                             Text.pack $ "duckdb-simple: row-parsing failed:" <> show errs
                         , sqlErrorType = Nothing
                         , sqlErrorQuery = Just query
+                        , sqlErrorCallStack = callStack
                         }
 
 renderError :: ResultError -> Text

--- a/duckdb-simple/src/Database/DuckDB/Simple/Function.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Function.hs
@@ -64,6 +64,8 @@ import Foreign.Marshal.Alloc (alloca)
 import Foreign.Ptr (Ptr, castPtr, freeHaskellFunPtr, nullPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, castStablePtrToPtr, deRefStablePtr, freeStablePtr, newStablePtr)
 import Foreign.Storable (poke, pokeElemOff)
+import Data.Vector.Internal.Check (HasCallStack)
+import GHC.Stack (callStack)
 
 data ScalarFunctionResources = ScalarFunctionResources
     { scalarFunctionExecPtr :: !DuckDBScalarFunctionFun
@@ -286,7 +288,7 @@ createFunctionWithState conn name initState mkFn = do
                     else throwIO (functionInvocationError (Text.pack "duckdb-simple: registering function failed"))
 
 -- | Drop a previously registered scalar function by issuing a DROP FUNCTION statement.
-deleteFunction :: Connection -> Text -> IO ()
+deleteFunction :: HasCallStack => Connection -> Text -> IO ()
 deleteFunction conn name =
     do
         outcome <-
@@ -311,6 +313,7 @@ deleteFunction conn name =
                                             { sqlErrorMessage = errMsg
                                             , sqlErrorType = Nothing
                                             , sqlErrorQuery = Just dropQuery
+                                            , sqlErrorCallStack = callStack
                                             }
         case outcome of
             Right () -> pure ()
@@ -497,12 +500,13 @@ argumentConversionError idx err =
                 ]
      in functionInvocationError message
 
-functionInvocationError :: Text -> SQLError
+functionInvocationError :: HasCallStack => Text -> SQLError
 functionInvocationError message =
     SQLError
         { sqlErrorMessage = message
         , sqlErrorType = Nothing
         , sqlErrorQuery = Nothing
+        , sqlErrorCallStack = callStack
         }
 
 fetchResultError :: Ptr DuckDBResult -> IO Text

--- a/duckdb-simple/src/Database/DuckDB/Simple/Internal.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Internal.hs
@@ -28,6 +28,7 @@ module Database.DuckDB.Simple.Internal (
     -- * Helpers
     connectionClosedError,
     statementClosedError,
+    appenderError,
     withDatabaseHandle,
     withConnectionHandle,
     withStatementHandle,
@@ -72,6 +73,7 @@ import Foreign.Marshal.Alloc (alloca)
 import Foreign.Ptr (Ptr, nullPtr)
 import Foreign.StablePtr (StablePtr, castPtrToStablePtr, freeStablePtr)
 import Foreign.Storable (peek, poke)
+import GHC.Stack (CallStack, callStack, HasCallStack)
 
 -- | Represents a textual SQL query with UTF-8 encoding semantics.
 newtype Query = Query
@@ -151,18 +153,20 @@ data SQLError = SQLError
     { sqlErrorMessage :: Text
     , sqlErrorType :: Maybe DuckDBErrorType
     , sqlErrorQuery :: Maybe Query
+    , sqlErrorCallStack :: CallStack
     }
-    deriving stock (Eq, Show)
+    deriving stock (Show)
 
 instance Exception SQLError
 
 -- | Convert an arbitrary exception into an untyped @SQLError@.
-toSQLError :: (Exception e) => e -> SQLError
+toSQLError :: (Exception e, HasCallStack) => e -> SQLError
 toSQLError ex =
     SQLError
         { sqlErrorMessage = Text.pack (show ex)
         , sqlErrorType = Nothing
         , sqlErrorQuery = Nothing
+        , sqlErrorCallStack = callStack
         }
 
 -- | Shared error value used when an operation targets a closed connection.
@@ -172,6 +176,7 @@ connectionClosedError =
         { sqlErrorMessage = Text.pack "duckdb-simple: connection is closed"
         , sqlErrorType = Nothing
         , sqlErrorQuery = Nothing
+        , sqlErrorCallStack = callStack
         }
 
 -- | Shared error value used when an operation targets a closed statement.
@@ -181,6 +186,16 @@ statementClosedError Statement{statementQuery} =
         { sqlErrorMessage = Text.pack "duckdb-simple: statement is closed"
         , sqlErrorType = Nothing
         , sqlErrorQuery = Just statementQuery
+        , sqlErrorCallStack = callStack
+        }
+
+appenderError :: Text -> SQLError
+appenderError msg =
+    SQLError
+        { sqlErrorMessage = Text.pack "duckdb-simple: appenderError: " <> msg
+        , sqlErrorType = Nothing
+        , sqlErrorQuery = Nothing
+        , sqlErrorCallStack = callStack
         }
 
 -- | Provide a UTF-8 encoded C string view of the query text.
@@ -236,13 +251,14 @@ destroyLogicalType logicalType =
     alloca $ \ptr -> poke ptr logicalType >> c_duckdb_destroy_logical_type ptr
 
 -- | Throw a standardised registration error.
-throwRegistrationError :: String -> IO a
+throwRegistrationError :: HasCallStack => String -> IO a
 throwRegistrationError label =
     throwIO
         SQLError
             { sqlErrorMessage = Text.pack ("duckdb-simple: " <> label <> " failed")
             , sqlErrorType = Nothing
             , sqlErrorQuery = Nothing
+            , sqlErrorCallStack = callStack
             }
 
 -- | Free a stable pointer stored behind a raw @Ptr ()@.

--- a/duckdb-simple/src/Database/DuckDB/Simple/Internal/ValueHelpers.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Internal/ValueHelpers.hs
@@ -24,54 +24,68 @@ import Foreign.Ptr (nullPtr)
 import Control.Monad (when)
 import Control.Exception (throwIO)
 import Data.Bits
-
 nullDuckValue :: IO DuckDBValue
 nullDuckValue = c_duckdb_create_null_value
+{-# INLINE nullDuckValue #-}
 
 boolDuckValue :: Bool -> IO DuckDBValue
 boolDuckValue value = c_duckdb_create_bool (if value then 1 else 0)
+{-# INLINE boolDuckValue #-}
 
 int8DuckValue :: Int8 -> IO DuckDBValue
 int8DuckValue = c_duckdb_create_int8
+{-# INLINE int8DuckValue #-}
 
 int16DuckValue :: Int16 -> IO DuckDBValue
 int16DuckValue = c_duckdb_create_int16
+{-# INLINE int16DuckValue #-}
 
 int32DuckValue :: Int32 -> IO DuckDBValue
 int32DuckValue = c_duckdb_create_int32
+{-# INLINE int32DuckValue #-}
 
 int64DuckValue :: Int64 -> IO DuckDBValue
 int64DuckValue = c_duckdb_create_int64
+{-# INLINE int64DuckValue #-}
 
 uint64DuckValue :: Word64 -> IO DuckDBValue
 uint64DuckValue = c_duckdb_create_uint64
+{-# INLINE uint64DuckValue #-}
 
 uint32DuckValue :: Word32 -> IO DuckDBValue
 uint32DuckValue = c_duckdb_create_uint32
+{-# INLINE uint32DuckValue #-}
 
 uint16DuckValue :: Word16 -> IO DuckDBValue
 uint16DuckValue = c_duckdb_create_uint16
+{-# INLINE uint16DuckValue #-}
 
 uint8DuckValue :: Word8 -> IO DuckDBValue
 uint8DuckValue = c_duckdb_create_uint8
+{-# INLINE uint8DuckValue #-}
 
 doubleDuckValue :: Double -> IO DuckDBValue
 doubleDuckValue = c_duckdb_create_double . CDouble
+{-# INLINE doubleDuckValue #-}
 
 floatDuckValue :: Float -> IO DuckDBValue
 floatDuckValue = c_duckdb_create_double . CDouble . realToFrac
+{-# INLINE floatDuckValue #-}
 
 textDuckValue :: Text -> IO DuckDBValue
-textDuckValue txt =
-    TextForeign.withCString txt c_duckdb_create_varchar
+textDuckValue txt = TextForeign.withCString txt c_duckdb_create_varchar
+{-# INLINE textDuckValue #-}
 
 stringDuckValue :: String -> IO DuckDBValue
 stringDuckValue = textDuckValue . Text.pack
+{-# INLINE stringDuckValue #-}
 
 blobDuckValue :: BS.ByteString -> IO DuckDBValue
 blobDuckValue bs =
     BS.useAsCStringLen bs \(ptr, len) ->
         c_duckdb_create_blob (castPtr ptr :: Ptr Word8) (fromIntegral len)
+{-# INLINE blobDuckValue #-}
+
 
 uuidDuckValue :: UUID.UUID -> IO DuckDBValue
 uuidDuckValue uuid =

--- a/duckdb-simple/src/Database/DuckDB/Simple/Internal/ValueHelpers.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Internal/ValueHelpers.hs
@@ -1,0 +1,271 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Database.DuckDB.Simple.Internal.ValueHelpers where
+
+import qualified Data.ByteString as BS
+import Data.Int (Int16, Int32, Int64, Int8)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Time (UTCTime, LocalTime (..), toGregorian, diffTimeToPicoseconds, timeOfDayToTime, TimeZone (timeZoneMinutes), utcToLocalTime, utc)
+import qualified Data.Text.Foreign as TextForeign
+
+import Data.Time.Calendar (Day)
+import Data.Time.LocalTime (TimeOfDay)
+import qualified Data.UUID as UUID
+import Data.Word (Word16, Word32, Word64, Word8)
+import Database.DuckDB.Simple.FromField (BigNum (..), BitString (..), IntervalValue (..), TimeWithZone (..), toBigNumBytes, DecimalValue (..))
+
+import Database.DuckDB.FFI
+import Foreign (alloca, Storable (poke), Ptr, castPtr)
+import Foreign.C.Types (CDouble (..))
+import Foreign.Marshal (fromBool)
+import Foreign.Ptr (nullPtr)
+import Control.Monad (when)
+import Control.Exception (throwIO)
+import Data.Bits
+
+nullDuckValue :: IO DuckDBValue
+nullDuckValue = c_duckdb_create_null_value
+
+boolDuckValue :: Bool -> IO DuckDBValue
+boolDuckValue value = c_duckdb_create_bool (if value then 1 else 0)
+
+int8DuckValue :: Int8 -> IO DuckDBValue
+int8DuckValue = c_duckdb_create_int8
+
+int16DuckValue :: Int16 -> IO DuckDBValue
+int16DuckValue = c_duckdb_create_int16
+
+int32DuckValue :: Int32 -> IO DuckDBValue
+int32DuckValue = c_duckdb_create_int32
+
+int64DuckValue :: Int64 -> IO DuckDBValue
+int64DuckValue = c_duckdb_create_int64
+
+uint64DuckValue :: Word64 -> IO DuckDBValue
+uint64DuckValue = c_duckdb_create_uint64
+
+uint32DuckValue :: Word32 -> IO DuckDBValue
+uint32DuckValue = c_duckdb_create_uint32
+
+uint16DuckValue :: Word16 -> IO DuckDBValue
+uint16DuckValue = c_duckdb_create_uint16
+
+uint8DuckValue :: Word8 -> IO DuckDBValue
+uint8DuckValue = c_duckdb_create_uint8
+
+doubleDuckValue :: Double -> IO DuckDBValue
+doubleDuckValue = c_duckdb_create_double . CDouble
+
+floatDuckValue :: Float -> IO DuckDBValue
+floatDuckValue = c_duckdb_create_double . CDouble . realToFrac
+
+textDuckValue :: Text -> IO DuckDBValue
+textDuckValue txt =
+    TextForeign.withCString txt c_duckdb_create_varchar
+
+stringDuckValue :: String -> IO DuckDBValue
+stringDuckValue = textDuckValue . Text.pack
+
+blobDuckValue :: BS.ByteString -> IO DuckDBValue
+blobDuckValue bs =
+    BS.useAsCStringLen bs \(ptr, len) ->
+        c_duckdb_create_blob (castPtr ptr :: Ptr Word8) (fromIntegral len)
+
+uuidDuckValue :: UUID.UUID -> IO DuckDBValue
+uuidDuckValue uuid =
+    alloca $ \ptr -> do
+        let (upper, lower) = UUID.toWords64 uuid
+        poke
+            ptr
+            DuckDBUHugeInt
+                { duckDBUHugeIntLower = lower
+                , duckDBUHugeIntUpper = upper
+                }
+        c_duckdb_create_uuid ptr
+
+bitDuckValue :: BitString -> IO DuckDBValue
+bitDuckValue (BitString padding bits) =
+    let withPacked action =
+            if BS.null bits
+                then alloca \ptr -> do
+                    poke
+                        ptr
+                        DuckDBBit
+                            { duckDBBitData = nullPtr
+                            , duckDBBitSize = 0
+                            }
+                    action ptr
+                else
+                    let payload = BS.pack ((fromIntegral padding :: Word8) : BS.unpack bits)
+                     in BS.useAsCStringLen payload \(rawPtr, len) ->
+                            alloca \ptr -> do
+                                poke
+                                    ptr
+                                    DuckDBBit
+                                        { duckDBBitData = castPtr rawPtr
+                                        , duckDBBitSize = fromIntegral len
+                                        }
+                                action ptr
+     in withPacked c_duckdb_create_bit
+
+bigNumDuckValue :: BigNum -> IO DuckDBValue
+bigNumDuckValue (BigNum big) =
+    let neg = fromBool (big < 0)
+        payload =
+            BS.pack $
+                if big < 0
+                    then map complement (drop 3 $ toBigNumBytes big)
+                    else drop 3 $ toBigNumBytes big
+        withPayload action =
+            if BS.null payload
+                then alloca \ptr -> do
+                    poke
+                        ptr
+                        DuckDBBignum
+                            { duckDBBignumData = nullPtr
+                            , duckDBBignumSize = 0
+                            , duckDBBignumIsNegative = neg
+                            }
+                    action ptr
+                else BS.useAsCStringLen payload \(rawPtr, len) ->
+                    alloca \ptr -> do
+                        poke
+                            ptr
+                            DuckDBBignum
+                                { duckDBBignumData = castPtr rawPtr
+                                , duckDBBignumSize = fromIntegral len
+                                , duckDBBignumIsNegative = neg
+                                }
+                        action ptr
+     in withPayload c_duckdb_create_bignum
+
+dayDuckValue :: Day -> IO DuckDBValue
+dayDuckValue day = do
+    duckDate <- encodeDay day
+    c_duckdb_create_date duckDate
+
+timeOfDayDuckValue :: TimeOfDay -> IO DuckDBValue
+timeOfDayDuckValue tod = do
+    duckTime <- encodeTimeOfDay tod
+    c_duckdb_create_time duckTime
+
+localTimeDuckValue :: LocalTime -> IO DuckDBValue
+localTimeDuckValue ts = do
+    duckTimestamp <- encodeLocalTime ts
+    c_duckdb_create_timestamp duckTimestamp
+
+utcTimeDuckValue :: UTCTime -> IO DuckDBValue
+utcTimeDuckValue utcTime =
+    let local = utcToLocalTime utc utcTime
+     in localTimeDuckValue local
+
+encodeDay :: Day -> IO DuckDBDate
+encodeDay day =
+    alloca \ptr -> do
+        poke ptr (dayToDateStruct day)
+        c_duckdb_to_date ptr
+
+encodeTimeOfDay :: TimeOfDay -> IO DuckDBTime
+encodeTimeOfDay tod =
+    alloca \ptr -> do
+        poke ptr (timeOfDayToStruct tod)
+        c_duckdb_to_time ptr
+
+encodeLocalTime :: LocalTime -> IO DuckDBTimestamp
+encodeLocalTime LocalTime{localDay, localTimeOfDay} =
+    alloca \ptr -> do
+        poke
+            ptr
+            DuckDBTimestampStruct
+                { duckDBTimestampStructDate = dayToDateStruct localDay
+                , duckDBTimestampStructTime = timeOfDayToStruct localTimeOfDay
+                }
+        c_duckdb_to_timestamp ptr
+
+dayToDateStruct :: Day -> DuckDBDateStruct
+dayToDateStruct day =
+    let (year, month, dayOfMonth) = toGregorian day
+     in DuckDBDateStruct
+            { duckDBDateStructYear = fromIntegral year
+            , duckDBDateStructMonth = fromIntegral month
+            , duckDBDateStructDay = fromIntegral dayOfMonth
+            }
+
+timeOfDayToStruct :: TimeOfDay -> DuckDBTimeStruct
+timeOfDayToStruct tod =
+    let totalPicoseconds = diffTimeToPicoseconds (timeOfDayToTime tod)
+        totalMicros = totalPicoseconds `div` 1000000
+        (hours, remHour) = totalMicros `divMod` (60 * 60 * 1000000)
+        (minutes, remMinute) = remHour `divMod` (60 * 1000000)
+        (seconds, micros) = remMinute `divMod` 1000000
+     in DuckDBTimeStruct
+            { duckDBTimeStructHour = fromIntegral hours
+            , duckDBTimeStructMinute = fromIntegral minutes
+            , duckDBTimeStructSecond = fromIntegral seconds
+            , duckDBTimeStructMicros = fromIntegral micros
+            }
+
+intervalDuckValue :: IntervalValue -> IO DuckDBValue
+intervalDuckValue IntervalValue{intervalMonths, intervalDays, intervalMicros} =
+    alloca \ptr -> do
+        poke ptr (DuckDBInterval intervalMonths intervalDays intervalMicros)
+        c_duckdb_create_interval ptr
+
+timeWithZoneDuckValue :: TimeWithZone -> IO DuckDBValue
+timeWithZoneDuckValue TimeWithZone{timeWithZoneTime, timeWithZoneZone} = do
+    let totalMicros = diffTimeToPicoseconds (timeOfDayToTime timeWithZoneTime) `div` 1000000
+        offsetSeconds = timeZoneMinutes timeWithZoneZone * 60
+    tzValue <- c_duckdb_create_time_tz (fromIntegral totalMicros) (fromIntegral offsetSeconds)
+    c_duckdb_create_time_tz_value tzValue
+
+
+hugeIntDuckValue :: Integer -> IO DuckDBValue
+hugeIntDuckValue value =
+    integerToHugeInt value >>= \huge ->
+        alloca \ptr -> do
+            poke ptr huge
+            c_duckdb_create_hugeint ptr
+
+uhugeIntDuckValue :: Integer -> IO DuckDBValue
+uhugeIntDuckValue value =
+    integerToUHugeInt value >>= \uhu ->
+        alloca \ptr -> do
+            poke ptr uhu
+            c_duckdb_create_uhugeint ptr
+
+decimalDuckValue :: DecimalValue -> IO DuckDBValue
+decimalDuckValue DecimalValue{decimalWidth, decimalScale, decimalInteger} = do
+    huge <- integerToHugeInt decimalInteger
+    alloca \ptr -> do
+        poke
+            ptr
+            DuckDBDecimal
+                { duckDBDecimalWidth = decimalWidth
+                , duckDBDecimalScale = decimalScale
+                , duckDBDecimalValue = huge
+                }
+        c_duckdb_create_decimal ptr
+
+integerToHugeInt :: Integer -> IO DuckDBHugeInt
+integerToHugeInt value = do
+    let minVal = negate (1 `shiftL` 127)
+        maxVal = (1 `shiftL` 127) - 1
+    when (value < minVal || value > maxVal) $
+        throwIO (userError "duckdb-simple: HUGEINT value out of range")
+    let lowerMask = (1 `shiftL` 64) - 1
+        lower = fromIntegral (value .&. lowerMask)
+        upper = fromIntegral (value `shiftR` 64)
+    pure DuckDBHugeInt{duckDBHugeIntLower = lower, duckDBHugeIntUpper = upper}
+
+integerToUHugeInt :: Integer -> IO DuckDBUHugeInt
+integerToUHugeInt value = do
+    let minVal = 0
+        maxVal = (1 `shiftL` 128) - 1
+    when (value < minVal || value > maxVal) $
+        throwIO (userError "duckdb-simple: UHUGEINT value out of range")
+    let lowerMask = (1 `shiftL` 64) - 1
+        lower = fromIntegral (value .&. lowerMask)
+        upper = fromIntegral (value `shiftR` 64)
+    pure DuckDBUHugeInt{duckDBUHugeIntLower = lower, duckDBUHugeIntUpper = upper}

--- a/duckdb-simple/src/Database/DuckDB/Simple/Internal/ValueHelpers.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/Internal/ValueHelpers.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 
 module Database.DuckDB.Simple.Internal.ValueHelpers where
 
@@ -7,8 +8,9 @@ import qualified Data.ByteString as BS
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import Data.Time (UTCTime, LocalTime (..), toGregorian, diffTimeToPicoseconds, timeOfDayToTime, TimeZone (timeZoneMinutes), utcToLocalTime, utc)
+import Data.Time (UTCTime, LocalTime (..), toGregorian, diffTimeToPicoseconds, timeOfDayToTime, TimeZone (timeZoneMinutes), utcToLocalTime, utc, pattern YearMonthDay)
 import qualified Data.Text.Foreign as TextForeign
+import Control.Monad (forM)
 
 import Data.Time.Calendar (Day)
 import Data.Time.LocalTime (TimeOfDay)
@@ -158,7 +160,7 @@ bigNumDuckValue (BigNum big) =
 dayDuckValue :: Day -> IO DuckDBValue
 dayDuckValue day = do
     duckDate <- encodeDay day
-    c_duckdb_create_date duckDate
+    maybe c_duckdb_create_null_value c_duckdb_create_date duckDate
 
 timeOfDayDuckValue :: TimeOfDay -> IO DuckDBValue
 timeOfDayDuckValue tod = do
@@ -168,17 +170,17 @@ timeOfDayDuckValue tod = do
 localTimeDuckValue :: LocalTime -> IO DuckDBValue
 localTimeDuckValue ts = do
     duckTimestamp <- encodeLocalTime ts
-    c_duckdb_create_timestamp duckTimestamp
+    maybe c_duckdb_create_null_value c_duckdb_create_timestamp duckTimestamp
 
 utcTimeDuckValue :: UTCTime -> IO DuckDBValue
 utcTimeDuckValue utcTime =
     let local = utcToLocalTime utc utcTime
      in localTimeDuckValue local
 
-encodeDay :: Day -> IO DuckDBDate
-encodeDay day =
+encodeDay :: Day -> IO (Maybe DuckDBDate)
+encodeDay day = forM (dayToDateStruct day) $ \dayStruct ->
     alloca \ptr -> do
-        poke ptr (dayToDateStruct day)
+        poke ptr dayStruct
         c_duckdb_to_date ptr
 
 encodeTimeOfDay :: TimeOfDay -> IO DuckDBTime
@@ -187,21 +189,24 @@ encodeTimeOfDay tod =
         poke ptr (timeOfDayToStruct tod)
         c_duckdb_to_time ptr
 
-encodeLocalTime :: LocalTime -> IO DuckDBTimestamp
+encodeLocalTime :: LocalTime -> IO (Maybe DuckDBTimestamp)
 encodeLocalTime LocalTime{localDay, localTimeOfDay} =
-    alloca \ptr -> do
-        poke
-            ptr
-            DuckDBTimestampStruct
-                { duckDBTimestampStructDate = dayToDateStruct localDay
-                , duckDBTimestampStructTime = timeOfDayToStruct localTimeOfDay
-                }
-        c_duckdb_to_timestamp ptr
+    forM (dayToDateStruct localDay) $ \dayStruct ->
+        alloca \ptr -> do
+            poke
+                ptr
+                DuckDBTimestampStruct
+                    { duckDBTimestampStructDate = dayStruct
+                    , duckDBTimestampStructTime = timeOfDayToStruct localTimeOfDay
+                    }
+            c_duckdb_to_timestamp ptr
 
-dayToDateStruct :: Day -> DuckDBDateStruct
+dayToDateStruct :: Day -> Maybe DuckDBDateStruct
+dayToDateStruct day | day < YearMonthDay (-5877642) 06 25 = Nothing
+dayToDateStruct day | day > YearMonthDay 5881580 07 10 = Nothing
 dayToDateStruct day =
     let (year, month, dayOfMonth) = toGregorian day
-     in DuckDBDateStruct
+     in Just $ DuckDBDateStruct
             { duckDBDateStructYear = fromIntegral year
             , duckDBDateStructMonth = fromIntegral month
             , duckDBDateStructDay = fromIntegral dayOfMonth

--- a/duckdb-simple/src/Database/DuckDB/Simple/ToField.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/ToField.hs
@@ -27,20 +27,18 @@ module Database.DuckDB.Simple.ToField (
 import Control.Exception (bracket, throwIO)
 import Control.Monad (when, zipWithM)
 import Data.Array (Array, elems)
-import Data.Bits (complement, shiftL, shiftR, (.&.))
 import qualified Data.ByteString as BS
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Text.Foreign as TextForeign
-import Data.Time.Calendar (Day, toGregorian)
-import Data.Time.Clock (UTCTime (..), diffTimeToPicoseconds)
-import Data.Time.LocalTime (LocalTime (..), TimeOfDay (..), TimeZone (..), timeOfDayToTime, timeZoneMinutes, utc, utcToLocalTime)
+import Data.Time.Calendar (Day)
+import Data.Time.Clock (UTCTime (..))
+import Data.Time.LocalTime (LocalTime (..), TimeOfDay (..))
 import qualified Data.UUID as UUID
 import Data.Word (Word16, Word32, Word64, Word8)
 import Database.DuckDB.FFI
-import Database.DuckDB.Simple.FromField (BigNum (..), BitString (..), DecimalValue (..), FieldValue (..), IntervalValue (..), TimeWithZone (..), toBigNumBytes)
+import Database.DuckDB.Simple.FromField (BigNum (..), BitString (..), DecimalValue (..), FieldValue (..))
 import Database.DuckDB.Simple.Internal (
     SQLError (..),
     Statement (..),
@@ -58,13 +56,12 @@ import Database.DuckDB.Simple.LogicalRep (
  )
 import Database.DuckDB.Simple.Types (Null (..))
 import Foreign.C.String (peekCString)
-import Foreign.C.Types (CDouble (..))
-import Foreign.Marshal (fromBool)
 import Foreign.Marshal.Alloc (alloca)
 import Foreign.Marshal.Array (withArray)
-import Foreign.Ptr (Ptr, castPtr, nullPtr)
+import Foreign.Ptr (Ptr, nullPtr)
 import Foreign.Storable (poke)
 import Numeric.Natural (Natural)
+import Database.DuckDB.Simple.Internal.ValueHelpers
 
 -- | Represents a named parameter binding using the @:=@ operator.
 data NamedParam where
@@ -269,142 +266,6 @@ instance (DuckDBColumnType a) => DuckDBColumnType (Array Int a) where
 nullBinding :: String -> FieldBinding
 nullBinding repr = valueBinding repr nullDuckValue
 
-nullDuckValue :: IO DuckDBValue
-nullDuckValue = c_duckdb_create_null_value
-
-boolDuckValue :: Bool -> IO DuckDBValue
-boolDuckValue value = c_duckdb_create_bool (if value then 1 else 0)
-
-int8DuckValue :: Int8 -> IO DuckDBValue
-int8DuckValue = c_duckdb_create_int8
-
-int16DuckValue :: Int16 -> IO DuckDBValue
-int16DuckValue = c_duckdb_create_int16
-
-int32DuckValue :: Int32 -> IO DuckDBValue
-int32DuckValue = c_duckdb_create_int32
-
-int64DuckValue :: Int64 -> IO DuckDBValue
-int64DuckValue = c_duckdb_create_int64
-
-uint64DuckValue :: Word64 -> IO DuckDBValue
-uint64DuckValue = c_duckdb_create_uint64
-
-uint32DuckValue :: Word32 -> IO DuckDBValue
-uint32DuckValue = c_duckdb_create_uint32
-
-uint16DuckValue :: Word16 -> IO DuckDBValue
-uint16DuckValue = c_duckdb_create_uint16
-
-uint8DuckValue :: Word8 -> IO DuckDBValue
-uint8DuckValue = c_duckdb_create_uint8
-
-doubleDuckValue :: Double -> IO DuckDBValue
-doubleDuckValue = c_duckdb_create_double . CDouble
-
-floatDuckValue :: Float -> IO DuckDBValue
-floatDuckValue = c_duckdb_create_double . CDouble . realToFrac
-
-textDuckValue :: Text -> IO DuckDBValue
-textDuckValue txt =
-    TextForeign.withCString txt c_duckdb_create_varchar
-
-stringDuckValue :: String -> IO DuckDBValue
-stringDuckValue = textDuckValue . Text.pack
-
-blobDuckValue :: BS.ByteString -> IO DuckDBValue
-blobDuckValue bs =
-    BS.useAsCStringLen bs \(ptr, len) ->
-        c_duckdb_create_blob (castPtr ptr :: Ptr Word8) (fromIntegral len)
-
-uuidDuckValue :: UUID.UUID -> IO DuckDBValue
-uuidDuckValue uuid =
-    alloca $ \ptr -> do
-        let (upper, lower) = UUID.toWords64 uuid
-        poke
-            ptr
-            DuckDBUHugeInt
-                { duckDBUHugeIntLower = lower
-                , duckDBUHugeIntUpper = upper
-                }
-        c_duckdb_create_uuid ptr
-
-bitDuckValue :: BitString -> IO DuckDBValue
-bitDuckValue (BitString padding bits) =
-    let withPacked action =
-            if BS.null bits
-                then alloca \ptr -> do
-                    poke
-                        ptr
-                        DuckDBBit
-                            { duckDBBitData = nullPtr
-                            , duckDBBitSize = 0
-                            }
-                    action ptr
-                else
-                    let payload = BS.pack ((fromIntegral padding :: Word8) : BS.unpack bits)
-                     in BS.useAsCStringLen payload \(rawPtr, len) ->
-                            alloca \ptr -> do
-                                poke
-                                    ptr
-                                    DuckDBBit
-                                        { duckDBBitData = castPtr rawPtr
-                                        , duckDBBitSize = fromIntegral len
-                                        }
-                                action ptr
-     in withPacked c_duckdb_create_bit
-
-bigNumDuckValue :: BigNum -> IO DuckDBValue
-bigNumDuckValue (BigNum big) =
-    let neg = fromBool (big < 0)
-        payload =
-            BS.pack $
-                if big < 0
-                    then map complement (drop 3 $ toBigNumBytes big)
-                    else drop 3 $ toBigNumBytes big
-        withPayload action =
-            if BS.null payload
-                then alloca \ptr -> do
-                    poke
-                        ptr
-                        DuckDBBignum
-                            { duckDBBignumData = nullPtr
-                            , duckDBBignumSize = 0
-                            , duckDBBignumIsNegative = neg
-                            }
-                    action ptr
-                else BS.useAsCStringLen payload \(rawPtr, len) ->
-                    alloca \ptr -> do
-                        poke
-                            ptr
-                            DuckDBBignum
-                                { duckDBBignumData = castPtr rawPtr
-                                , duckDBBignumSize = fromIntegral len
-                                , duckDBBignumIsNegative = neg
-                                }
-                        action ptr
-     in withPayload c_duckdb_create_bignum
-
-dayDuckValue :: Day -> IO DuckDBValue
-dayDuckValue day = do
-    duckDate <- encodeDay day
-    c_duckdb_create_date duckDate
-
-timeOfDayDuckValue :: TimeOfDay -> IO DuckDBValue
-timeOfDayDuckValue tod = do
-    duckTime <- encodeTimeOfDay tod
-    c_duckdb_create_time duckTime
-
-localTimeDuckValue :: LocalTime -> IO DuckDBValue
-localTimeDuckValue ts = do
-    duckTimestamp <- encodeLocalTime ts
-    c_duckdb_create_timestamp duckTimestamp
-
-utcTimeDuckValue :: UTCTime -> IO DuckDBValue
-utcTimeDuckValue utcTime =
-    let local = utcToLocalTime utc utcTime
-     in localTimeDuckValue local
-
 arrayDuckValue ::
     forall a.
     (DuckDBColumnType a, ToDuckValue a) =>
@@ -580,68 +441,6 @@ enumDuckValue dict idx = do
     destroyLogicalType enumLogical
     pure result
 
-hugeIntDuckValue :: Integer -> IO DuckDBValue
-hugeIntDuckValue value =
-    integerToHugeInt value >>= \huge ->
-        alloca \ptr -> do
-            poke ptr huge
-            c_duckdb_create_hugeint ptr
-
-uhugeIntDuckValue :: Integer -> IO DuckDBValue
-uhugeIntDuckValue value =
-    integerToUHugeInt value >>= \uhu ->
-        alloca \ptr -> do
-            poke ptr uhu
-            c_duckdb_create_uhugeint ptr
-
-decimalDuckValue :: DecimalValue -> IO DuckDBValue
-decimalDuckValue DecimalValue{decimalWidth, decimalScale, decimalInteger} = do
-    huge <- integerToHugeInt decimalInteger
-    alloca \ptr -> do
-        poke
-            ptr
-            DuckDBDecimal
-                { duckDBDecimalWidth = decimalWidth
-                , duckDBDecimalScale = decimalScale
-                , duckDBDecimalValue = huge
-                }
-        c_duckdb_create_decimal ptr
-
-intervalDuckValue :: IntervalValue -> IO DuckDBValue
-intervalDuckValue IntervalValue{intervalMonths, intervalDays, intervalMicros} =
-    alloca \ptr -> do
-        poke ptr (DuckDBInterval intervalMonths intervalDays intervalMicros)
-        c_duckdb_create_interval ptr
-
-timeWithZoneDuckValue :: TimeWithZone -> IO DuckDBValue
-timeWithZoneDuckValue TimeWithZone{timeWithZoneTime, timeWithZoneZone} = do
-    let totalMicros = diffTimeToPicoseconds (timeOfDayToTime timeWithZoneTime) `div` 1000000
-        offsetSeconds = timeZoneMinutes timeWithZoneZone * 60
-    tzValue <- c_duckdb_create_time_tz (fromIntegral totalMicros) (fromIntegral offsetSeconds)
-    c_duckdb_create_time_tz_value tzValue
-
-integerToHugeInt :: Integer -> IO DuckDBHugeInt
-integerToHugeInt value = do
-    let minVal = negate (1 `shiftL` 127)
-        maxVal = (1 `shiftL` 127) - 1
-    when (value < minVal || value > maxVal) $
-        throwIO (userError "duckdb-simple: HUGEINT value out of range")
-    let lowerMask = (1 `shiftL` 64) - 1
-        lower = fromIntegral (value .&. lowerMask)
-        upper = fromIntegral (value `shiftR` 64)
-    pure DuckDBHugeInt{duckDBHugeIntLower = lower, duckDBHugeIntUpper = upper}
-
-integerToUHugeInt :: Integer -> IO DuckDBUHugeInt
-integerToUHugeInt value = do
-    let minVal = 0
-        maxVal = (1 `shiftL` 128) - 1
-    when (value < minVal || value > maxVal) $
-        throwIO (userError "duckdb-simple: UHUGEINT value out of range")
-    let lowerMask = (1 `shiftL` 64) - 1
-        lower = fromIntegral (value .&. lowerMask)
-        upper = fromIntegral (value `shiftR` 64)
-    pure DuckDBUHugeInt{duckDBUHugeIntLower = lower, duckDBUHugeIntUpper = upper}
-
 withDuckValues :: [DuckDBValue] -> (Ptr DuckDBValue -> IO a) -> IO a
 withDuckValues xs action = withArray xs action
 
@@ -794,52 +593,6 @@ instance ToDuckValue (UnionValue FieldValue) where
 instance (ToDuckValue a) => ToDuckValue (Maybe a) where
     toDuckValue Nothing = nullDuckValue
     toDuckValue (Just value) = toDuckValue value
-
-encodeDay :: Day -> IO DuckDBDate
-encodeDay day =
-    alloca \ptr -> do
-        poke ptr (dayToDateStruct day)
-        c_duckdb_to_date ptr
-
-encodeTimeOfDay :: TimeOfDay -> IO DuckDBTime
-encodeTimeOfDay tod =
-    alloca \ptr -> do
-        poke ptr (timeOfDayToStruct tod)
-        c_duckdb_to_time ptr
-
-encodeLocalTime :: LocalTime -> IO DuckDBTimestamp
-encodeLocalTime LocalTime{localDay, localTimeOfDay} =
-    alloca \ptr -> do
-        poke
-            ptr
-            DuckDBTimestampStruct
-                { duckDBTimestampStructDate = dayToDateStruct localDay
-                , duckDBTimestampStructTime = timeOfDayToStruct localTimeOfDay
-                }
-        c_duckdb_to_timestamp ptr
-
-dayToDateStruct :: Day -> DuckDBDateStruct
-dayToDateStruct day =
-    let (year, month, dayOfMonth) = toGregorian day
-     in DuckDBDateStruct
-            { duckDBDateStructYear = fromIntegral year
-            , duckDBDateStructMonth = fromIntegral month
-            , duckDBDateStructDay = fromIntegral dayOfMonth
-            }
-
-timeOfDayToStruct :: TimeOfDay -> DuckDBTimeStruct
-timeOfDayToStruct tod =
-    let totalPicoseconds = diffTimeToPicoseconds (timeOfDayToTime tod)
-        totalMicros = totalPicoseconds `div` 1000000
-        (hours, remHour) = totalMicros `divMod` (60 * 60 * 1000000)
-        (minutes, remMinute) = remHour `divMod` (60 * 1000000)
-        (seconds, micros) = remMinute `divMod` 1000000
-     in DuckDBTimeStruct
-            { duckDBTimeStructHour = fromIntegral hours
-            , duckDBTimeStructMinute = fromIntegral minutes
-            , duckDBTimeStructSecond = fromIntegral seconds
-            , duckDBTimeStructMicros = fromIntegral micros
-            }
 
 bindDuckValue :: Statement -> DuckDBIdx -> IO DuckDBValue -> IO ()
 bindDuckValue stmt idx makeValue =

--- a/duckdb-simple/src/Database/DuckDB/Simple/ToField.hs
+++ b/duckdb-simple/src/Database/DuckDB/Simple/ToField.hs
@@ -62,6 +62,7 @@ import Foreign.Ptr (Ptr, nullPtr)
 import Foreign.Storable (poke)
 import Numeric.Natural (Natural)
 import Database.DuckDB.Simple.Internal.ValueHelpers
+import GHC.Stack (HasCallStack, callStack)
 
 -- | Represents a named parameter binding using the @:=@ operator.
 data NamedParam where
@@ -455,7 +456,7 @@ typeMismatch expected actual =
             )
         )
 
-createElementLogicalType :: forall a. (DuckDBColumnType a) => Proxy a -> IO DuckDBLogicalType
+createElementLogicalType :: HasCallStack => forall a. (DuckDBColumnType a) => Proxy a -> IO DuckDBLogicalType
 createElementLogicalType proxy =
     let typeName = duckdbColumnType proxy
      in case duckDBTypeFromName typeName of
@@ -470,6 +471,7 @@ createElementLogicalType proxy =
                                 ]
                         , sqlErrorType = Nothing
                         , sqlErrorQuery = Nothing
+                        , sqlErrorCallStack = callStack
                         }
                     )
 
@@ -623,4 +625,5 @@ throwBindError Statement{statementQuery} msg =
             { sqlErrorMessage = msg
             , sqlErrorType = Nothing
             , sqlErrorQuery = Just statementQuery
+            , sqlErrorCallStack = callStack
             }

--- a/duckdb-simple/test/Appender.hs
+++ b/duckdb-simple/test/Appender.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Appender (appenderTests) where
+
+import Data.Proxy (Proxy (..))
+import Data.Time.Calendar (pattern YearMonthDay)
+import Data.Time.Clock (UTCTime (..))
+import Database.DuckDB.Simple
+import GHC.Generics (Generic)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit
+import Data.Text (Text)
+import Database.DuckDB.Simple.Appender
+import Data.Aeson (Value)
+import Data.ByteString (ByteString)
+import qualified Data.Aeson as A
+
+data LogLine =
+  LogLine
+  { timestamp :: UTCTime
+  , message :: Text
+  , severity :: Severity
+  , payload :: Payload
+  }
+  deriving stock (Generic)
+  deriving anyclass (AppendTableRow)
+  deriving (AppenderDuckValue) via (ViaDuckStruct LogLine)
+
+data Payload =
+  PayloadJSON { json :: Value }
+  | PayloadBinary { summary :: Text, bytes :: ByteString }
+  | PayloadNested { summary :: Text, nested :: Nested }
+  | NoPayload
+  deriving stock (Generic)
+  deriving AppenderDuckValue via (ViaDuckUnion Payload)
+
+data Nested = Nested { foo :: Text, bar :: Int }
+  deriving stock (Generic)
+  deriving AppenderDuckValue via (ViaDuckStruct Nested)
+
+
+data Severity = Error | Warning | Info
+  deriving stock (Generic)
+  deriving AppenderDuckValue via (ViaDuckEnum Severity)
+
+data SimpleUnion = Foo Int | Bar Text | Baz UTCTime
+  deriving stock (Generic)
+  deriving AppenderDuckValue via (ViaDuckUnion SimpleUnion)
+
+data SimpleUnion2 = Foo2 { foo2 :: Int } | Bar2 { bar2 :: Text } | Baz2 { baz2 :: UTCTime }
+  deriving stock (Generic)
+  deriving AppenderDuckValue via (ViaDuckUnion SimpleUnion2)
+
+data SimpleUnion3 = Foo3 { foo3 :: Int, foo3Bool :: Bool } | Bar3 { bar3 :: Text, bar3Int :: Int } | Baz3 { baz3 :: UTCTime } | NoFieldsHere
+  deriving stock (Generic)
+  deriving AppenderDuckValue via (ViaDuckUnion SimpleUnion3)
+
+data SimpleStruct = SimpleStruct { a :: Int, b :: Bool, c :: UTCTime}
+  deriving stock (Generic)
+  deriving AppenderDuckValue via (ViaDuckStruct SimpleStruct)
+
+data SimpleEnum = A | B | C | D | Other
+  deriving stock (Generic)
+  deriving AppenderDuckValue via (ViaDuckEnum SimpleEnum)
+
+
+sometime :: UTCTime
+sometime = UTCTime (YearMonthDay 2026 05 11) 123
+
+appenderTests :: TestTree
+appenderTests =
+    testGroup
+        "appender"
+        [
+        testCase "generates a proper table schema" $
+                  "CREATE TABLE \"logs\" (\"timestamp\" TIMESTAMPTZ, \n\"message\" VARCHAR, \n\"severity\" ENUM('Error', 'Warning', 'Info'), \n\"payload\" UNION(\"PayloadJSON\" JSON, \"PayloadBinary\" STRUCT(\"summary\" VARCHAR, \"bytes\" BLOB), \"PayloadNested\" STRUCT(\"summary\" VARCHAR, \"nested\" STRUCT(\"foo\" VARCHAR, \"bar\" BIGINT)), \"NoPayload\" TINYINT))"
+                  @=?
+                  createTableQuery "logs" (Proxy @LogLine)
+        , testCase "schema: union unnamed" $
+                "UNION(\"Foo\" BIGINT, \"Bar\" VARCHAR, \"Baz\" TIMESTAMPTZ)" @=? renderDuckTypeName (appenderTypeName $ Proxy @SimpleUnion)
+        , testCase "schema: union named " $
+                "UNION(\"Foo2\" BIGINT, \"Bar2\" VARCHAR, \"Baz2\" TIMESTAMPTZ)" @=? renderDuckTypeName (appenderTypeName $ Proxy @SimpleUnion2)
+        , testCase "schema: union structs" $
+                 "UNION(\"Foo3\" STRUCT(\"foo3\" BIGINT, \"foo3Bool\" BOOL), \"Bar3\" STRUCT(\"bar3\" VARCHAR, \"bar3Int\" BIGINT), \"Baz3\" TIMESTAMPTZ, \"NoFieldsHere\" TINYINT)" @=? renderDuckTypeName (appenderTypeName $ Proxy @SimpleUnion3)
+        , testCase "schema: structs" $
+                  "STRUCT(\"a\" BIGINT, \"b\" BOOL, \"c\" TIMESTAMPTZ)" @=? renderDuckTypeName (appenderTypeName $ Proxy @SimpleStruct)
+        , testCase "schema: enums" $
+                  "ENUM('A', 'B', 'C', 'D', 'Other')" @=? renderDuckTypeName (appenderTypeName $ Proxy @SimpleEnum)
+        , testCase "withTableAppender appends" $
+            withConnection ":memory:" \conn -> do
+                _ <- execute_ conn $ createTableQuery "logs" (Proxy @LogLine)
+                withTableAppender conn "logs" $ \app -> do
+                  mapM_ (appendTableRow app)
+                    [ LogLine sometime "message A" Error (PayloadJSON $ A.object ["foo" A..= A.Null, "bar" A..= (123 :: Int)])
+                    , LogLine sometime "message B" Info (PayloadBinary "descr" "bytes")
+                    , LogLine sometime "message C" Warning (PayloadNested "descr" (Nested "foo" 123))
+                    , LogLine sometime "message D" Warning NoPayload
+                    ]
+                rows <- query_ conn "SELECT COUNT(*) FROM logs" :: IO [Only Int]
+                assertEqual "rows" [Only 3] rows
+        ]

--- a/duckdb-simple/test/Appender.hs
+++ b/duckdb-simple/test/Appender.hs
@@ -95,7 +95,7 @@ appenderTests =
                   "ENUM('A', 'B', 'C', 'D', 'Other')" @=? renderDuckTypeName (appenderTypeName $ Proxy @SimpleEnum)
         , testCase "withTableAppender appends" $
             withConnection ":memory:" \conn -> do
-                _ <- execute_ conn $ createTableQuery "logs" (Proxy @LogLine)
+                _ <- execute_ conn (createTableQuery "logs" (Proxy @LogLine))
                 withTableAppender conn "logs" $ \app -> do
                   mapM_ (appendTableRow app)
                     [ LogLine sometime "message A" Error (PayloadJSON $ A.object ["foo" A..= A.Null, "bar" A..= (123 :: Int)])
@@ -104,5 +104,5 @@ appenderTests =
                     , LogLine sometime "message D" Warning NoPayload
                     ]
                 rows <- query_ conn "SELECT COUNT(*) FROM logs" :: IO [Only Int]
-                assertEqual "rows" [Only 3] rows
+                [Only 4] @=? rows
         ]

--- a/duckdb-simple/test/Appender.hs
+++ b/duckdb-simple/test/Appender.hs
@@ -47,7 +47,7 @@ data Nested = Nested { foo :: Text, bar :: Int }
 
 
 data Severity = Error | Warning | Info
-  deriving stock (Generic)
+  deriving stock (Generic, Show, Enum)
   deriving AppenderDuckValue via (ViaDuckEnum Severity)
 
 data SimpleUnion = Foo Int | Bar Text | Baz UTCTime
@@ -67,7 +67,7 @@ data SimpleStruct = SimpleStruct { a :: Int, b :: Bool, c :: UTCTime}
   deriving AppenderDuckValue via (ViaDuckStruct SimpleStruct)
 
 data SimpleEnum = A | B | C | D | Other
-  deriving stock (Generic)
+  deriving stock (Generic, Show, Enum)
   deriving AppenderDuckValue via (ViaDuckEnum SimpleEnum)
 
 

--- a/duckdb-simple/test/Appender.hs
+++ b/duckdb-simple/test/Appender.hs
@@ -15,12 +15,13 @@ import Data.Time.Clock (UTCTime (..))
 import Database.DuckDB.Simple
 import GHC.Generics (Generic)
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit
+import Test.Tasty.HUnit ( testCase, (@=?) )
 import Data.Text (Text)
 import Database.DuckDB.Simple.Appender
 import Data.Aeson (Value)
-import Data.ByteString (ByteString)
 import qualified Data.Aeson as A
+import Data.Map ( Map )
+import qualified Data.Map as Map
 
 data LogLine =
   LogLine
@@ -29,20 +30,21 @@ data LogLine =
   , severity :: Severity
   , payload :: Payload
   }
-  deriving stock (Generic)
+  deriving stock (Generic, Show)
   deriving anyclass (AppendTableRow)
   deriving (AppenderDuckValue) via (ViaDuckStruct LogLine)
 
 data Payload =
   PayloadJSON { json :: Value }
-  | PayloadBinary { summary :: Text, bytes :: ByteString }
-  | PayloadNested { summary :: Text, nested :: Nested }
+  | PayloadBinary { summary :: Text, bytes :: Text }
+  | PayloadNested { info :: Maybe Text, nested :: Nested }
   | NoPayload
-  deriving stock (Generic)
+  | PayloadList { list :: [Text], map :: Map Text Int}
+  deriving stock (Generic, Show)
   deriving AppenderDuckValue via (ViaDuckUnion Payload)
 
 data Nested = Nested { foo :: Text, bar :: Int }
-  deriving stock (Generic)
+  deriving stock (Generic, Show)
   deriving AppenderDuckValue via (ViaDuckStruct Nested)
 
 
@@ -80,7 +82,7 @@ appenderTests =
         "appender"
         [
         testCase "generates a proper table schema" $
-                  "CREATE TABLE \"logs\" (\"timestamp\" TIMESTAMPTZ, \n\"message\" VARCHAR, \n\"severity\" ENUM('Error', 'Warning', 'Info'), \n\"payload\" UNION(\"PayloadJSON\" JSON, \"PayloadBinary\" STRUCT(\"summary\" VARCHAR, \"bytes\" BLOB), \"PayloadNested\" STRUCT(\"summary\" VARCHAR, \"nested\" STRUCT(\"foo\" VARCHAR, \"bar\" BIGINT)), \"NoPayload\" TINYINT))"
+                  "CREATE TABLE \"logs\" (\"timestamp\" TIMESTAMPTZ, \n\"message\" VARCHAR, \n\"severity\" ENUM('Error', 'Warning', 'Info'), \n\"payload\" UNION(\"PayloadJSON\" JSON, \"PayloadBinary\" STRUCT(\"summary\" VARCHAR, \"bytes\" VARCHAR), \"PayloadNested\" STRUCT(\"info\" VARCHAR, \"nested\" STRUCT(\"foo\" VARCHAR, \"bar\" BIGINT)), \"NoPayload\" TINYINT, \"PayloadList\" STRUCT(\"list\" VARCHAR[], \"map\" MAP(VARCHAR, BIGINT))))"
                   @=?
                   createTableQuery "logs" (Proxy @LogLine)
         , testCase "schema: union unnamed" $
@@ -95,14 +97,15 @@ appenderTests =
                   "ENUM('A', 'B', 'C', 'D', 'Other')" @=? renderDuckTypeName (appenderTypeName $ Proxy @SimpleEnum)
         , testCase "withTableAppender appends" $
             withConnection ":memory:" \conn -> do
-                _ <- execute_ conn (createTableQuery "logs" (Proxy @LogLine))
+                _ <- execute_ conn $ createTableQuery "logs" (Proxy @LogLine)
                 withTableAppender conn "logs" $ \app -> do
                   mapM_ (appendTableRow app)
-                    [ LogLine sometime "message A" Error (PayloadJSON $ A.object ["foo" A..= A.Null, "bar" A..= (123 :: Int)])
+                    [ LogLine sometime "message A" Error  (PayloadJSON $ A.object ["foo" A..= A.Null, "bar" A..= (123 :: Int)])
                     , LogLine sometime "message B" Info (PayloadBinary "descr" "bytes")
-                    , LogLine sometime "message C" Warning (PayloadNested "descr" (Nested "foo" 123))
+                    , LogLine sometime "message C" Warning (PayloadNested Nothing (Nested "foo" 123))
                     , LogLine sometime "message D" Warning NoPayload
+                    , LogLine sometime "message E" Warning (PayloadList ["foo", "bar", "baz"] (Map.fromList [("foo", 2), ("bar", 3)]))
                     ]
                 rows <- query_ conn "SELECT COUNT(*) FROM logs" :: IO [Only Int]
-                [Only 4] @=? rows
+                [Only 5] @=? rows
         ]

--- a/duckdb-simple/test/Spec.hs
+++ b/duckdb-simple/test/Spec.hs
@@ -84,6 +84,7 @@ import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.ExpectedFailure (expectFailBecause)
 import Test.Tasty.HUnit
 import Test.Tasty.QuickCheck (testProperty, (===))
+import Appender (appenderTests)
 
 data Person = Person
     { personId :: Int
@@ -188,6 +189,7 @@ nonEmptyTextParser f@Field{} =
 
 instance FromField NonEmptyText where
     fromField = nonEmptyTextParser
+
 main :: IO ()
 main = defaultMain tests
 
@@ -204,6 +206,7 @@ tests =
         , functionsTests
         , v15Tests
         , transactionTests
+        , appenderTests
         ]
 
 connectionTests :: TestTree


### PR DESCRIPTION
My use case is to use DuckDB as a data sink to later export data to Parquet (or another format) and due to the volume of data I want to convert from haskell-managed binary format I need decent performance. [INSERT statements are slow](https://duckdb.org/docs/current/clients/c/appender), therefore we need to use appender API.

I do serialize relatively complex nested data structure to struct, unions and enums and converting it to DuckDBValue is not that fast. First, I attempted to extend existing type classes to support appender API. While I was somehow successful, although not happy with the complexity there, I still saw some opportunities to improve performance. Therefore I decided to roll [my own](https://xkcd.com/927/) type class that will skip intermediate representation (`FieldValue`) and marshall to DuckDB directly. This is only one way, as I don't intend to read it from Haskell. So far, I was able to increase throughput by factor of 2 compared to stock generic implementation.

One of meaningful improvements that can easily be ported is caching `DuckDBLogicalType` (I do this via "static" IORef), as they need to be materialized whenever a value is created. In some earlier iterations I did that on the stock implementation and that alone was extra ~40% improvement.

At this point, the DB type representation that is generated by Appender.Generic is not compatible with Generic that already exists in the library. This can be unified, as I noticed a few bugs/corner cases that were not handled nicely by the stock implementation. This is definitely not finished, but is usable at this point and I think it's worth sharing at this point.